### PR TITLE
Revert "Added HMM_FastInverseSquareRoot function"

### DIFF
--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -223,7 +223,6 @@ HMMDEF float HMM_ToRadians(float Degrees);
 HMMDEF float HMM_Inner(hmm_vec3 A, hmm_vec3 B);
 HMMDEF float HMM_SquareRoot(float Float);
 HMMDEF float HMM_LengthSquareRoot(hmm_vec3 A);
-HMMDEF float HMM_FastInverseSquareRoot(float Number);
 HMMDEF float HMM_Length(hmm_vec3 A);    
 HMMDEF float HMM_Power(float Base, int Exponent);
 HMMDEF float HMM_Clamp(float Min, float Value, float Max);
@@ -350,24 +349,6 @@ HMM_LengthSquareRoot(hmm_vec3 A)
     float Result = HMM_Inner(A, A);
 
     return (Result);
-}
-
-HINLINE float
-HMM_FastInverseSquareRoot(float Number)
-{
-    long i;
-    float x2, y;
-    const float threehalfs = 1.5f;
-
-    x2 = Number * 0.5f;
-    y  = Number;
-    i  = * ( long * ) &y;          // evil floating point bit level hacking
-    i  = 0x5f3759df - ( i >> 1 );  // what the fuck? 
-    y  = * ( float * ) &i;
-    
-    y  = y * ( threehalfs - ( x2 * y * y ) );
-
-    return ( y );
 }
 
 HINLINE float


### PR DESCRIPTION
Reverts ZakStrange/Handmade-Math#7



Actually, perhaps you should revert this pull request, as it might give people the wrong idea. From referenced video:

Mārtiņš Možeiko commented:

It is worth mentioning that this method of calculating rsqrt nowadays is not so fast anymore. Modern CPU's have builtin instruction to calculate rsqrt and is faster than this function. Just one instruction and you got result. What more accuracy? Do a Newton iteration on top of it. See here - http://assemblyrequired.crashworks.org/timing-square-root/ Already in 2009 rsqrtss + Newton iteration step was faster than Q_rsqrt. Of course, Q_rsqrt is very interesting by itself and a coold thing to learn about.﻿