### PR TITLE
Various changes

### DIFF
--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -802,6 +802,8 @@ HMM_Rotate(float Angle, hmm_vec3 Axis)
 {
     hmm_mat4 Result = HMM_Mat4d(1.0f);
     
+    Axis = HMM_Normalize(Axis);
+    
     float SinTheta = sinf(HMM_ToRadians(Angle));
     float CosTheta = cosf(HMM_ToRadians(Angle));
     float CosValue = 1.0f - CosTheta;

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -804,18 +804,19 @@ HMM_Rotate(float Angle, hmm_vec3 Axis)
     
     float SinTheta = sinf(HMM_ToRadians(Angle));
     float CosTheta = cosf(HMM_ToRadians(Angle));
+    float CosValue = 1.0f - CosTheta;
     
-    Result.Elements[0][0] = (Axis.X * Axis.X * (1.0f - CosTheta)) + CosTheta;
-    Result.Elements[0][1] = (Axis.X * Axis.Y * (1.0f - CosTheta)) - (Axis.Z * SinTheta);
-    Result.Elements[0][2] = (Axis.X * Axis.Z * (1.0f - CosTheta)) + (Axis.Y * SinTheta);
+    Result.Elements[0][0] = (Axis.X * Axis.X * CosValue + CosTheta;
+    Result.Elements[0][1] = (Axis.X * Axis.Y * CosValue) - (Axis.Z * SinTheta);
+    Result.Elements[0][2] = (Axis.X * Axis.Z * CosValue) + (Axis.Y * SinTheta);
     
-    Result.Elements[1][0] = (Axis.Y * Axis.X * (1.0f - CosTheta)) + (Axis.Z * SinTheta);
-    Result.Elements[1][1] = (Axis.Y * Axis.Y * (1.0f - CosTheta)) + CosTheta;
-    Result.Elements[1][2] = (Axis.Y * Axis.Z * (1.0f - CosTheta)) - (Axis.X * SinTheta);
+    Result.Elements[1][0] = (Axis.Y * Axis.X * CosValue) + (Axis.Z * SinTheta);
+    Result.Elements[1][1] = (Axis.Y * Axis.Y * CosValue) + CosTheta;
+    Result.Elements[1][2] = (Axis.Y * Axis.Z * CosValue) - (Axis.X * SinTheta);
     
-    Result.Elements[2][0] = (Axis.Z * Axis.X * (1.0f - CosTheta)) - (Axis.Y * SinTheta);
-    Result.Elements[2][1] = (Axis.Z * Axis.Y * (1.0f - CosTheta)) + (Axis.X * SinTheta);
-    Result.Elements[2][2] = (Axis.Z * Axis.Z * (1.0f - CosTheta)) + CosTheta);
+    Result.Elements[2][0] = (Axis.Z * Axis.X * CosValue) - (Axis.Y * SinTheta);
+    Result.Elements[2][1] = (Axis.Z * Axis.Y * CosValue) + (Axis.X * SinTheta);
+    Result.Elements[2][2] = (Axis.Z * Axis.Z * CosValue) + CosTheta;
     
     return (Result);
 }

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -809,12 +809,12 @@ HMM_Rotate(float Angle, hmm_vec3 Axis)
     Result.Elements[0][1] = (Axis.X * Axis.Y * (1.0f - CosTheta)) - (Axis.Z * SinTheta);
     Result.Elements[0][2] = (Axis.X * Axis.Z * (1.0f - CosTheta)) + (Axis.Y * SinTheta);
     
-    Result.Elements[1][0] = (Axis.X * Axis.Y * (1.0f - CosTheta)) + (Axis.Z * SinTheta);
+    Result.Elements[1][0] = (Axis.Y * Axis.X * (1.0f - CosTheta)) + (Axis.Z * SinTheta);
     Result.Elements[1][1] = (Axis.Y * Axis.Y * (1.0f - CosTheta)) + CosTheta;
     Result.Elements[1][2] = (Axis.Y * Axis.Z * (1.0f - CosTheta)) - (Axis.X * SinTheta);
     
-    Result.Elements[2][0] = (Axis.X * Axis.Z * (1.0f - CosTheta)) - (Axis.Y * SinTheta);
-    Result.Elements[2][1] = (Axis.Y * Axis.Z * (1.0f - CosTheta)) + (Axis.X * SinTheta);
+    Result.Elements[2][0] = (Axis.Z * Axis.X * (1.0f - CosTheta)) - (Axis.Y * SinTheta);
+    Result.Elements[2][1] = (Axis.Z * Axis.Y * (1.0f - CosTheta)) + (Axis.X * SinTheta);
     Result.Elements[2][2] = (Axis.Z * Axis.Z * (1.0f - CosTheta)) + CosTheta);
     
     return (Result);

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -800,19 +800,22 @@ hmm_mat4
 HMM_Rotate(float Angle, hmm_vec3 Axis)
 {
     hmm_mat4 Result = HMM_Mat4d(1.0f);
-
-    Result.Elements[0][0] = Axis.X * Axis.X * (1.0f - cosf(HMM_ToRadians(Angle))) + cosf(HMM_ToRadians(Angle));
-    Result.Elements[0][1] = Axis.Y * Axis.X * (1.0f - cosf(HMM_ToRadians(Angle))) + Axis.Z * (sinf(HMM_ToRadians(Angle)));
-    Result.Elements[0][2] = Axis.X * Axis.Z * (1.0f - cosf(HMM_ToRadians(Angle))) - Axis.Y * (sinf(HMM_ToRadians(Angle)));
-
-    Result.Elements[1][0] = Axis.X * Axis.Y * (1.0f - cosf(HMM_ToRadians(Angle))) - Axis.Z * (sinf(HMM_ToRadians(Angle)));
-    Result.Elements[1][1] = Axis.Y * Axis.Y * (1.0f - cosf(HMM_ToRadians(Angle))) + (cosf(HMM_ToRadians(Angle)));
-    Result.Elements[1][2] = Axis.Y * Axis.Z * (1.0f - cosf(HMM_ToRadians(Angle))) + Axis.X * (sinf(HMM_ToRadians(Angle)));
-
-    Result.Elements[2][0] = Axis.X * Axis.Z * (1.0f - cosf(HMM_ToRadians(Angle))) + Axis.Y * (sinf(HMM_ToRadians(Angle)));
-    Result.Elements[2][1] = Axis.Y * Axis.Z * (1.0f - cosf(HMM_ToRadians(Angle))) - Axis.X * (sinf(HMM_ToRadians(Angle)));
-    Result.Elements[2][2] = Axis.Z * Axis.Z * (1.0f - cosf(HMM_ToRadians(Angle))) * (cosf(HMM_ToRadians(Angle)));
-
+    
+    SinTheta = sinf(HMM_ToRadians(Angle));
+    CosTheta = cosf(HMM_ToRadians(Angle));
+    
+    Result.Elements[0][0] = (Axis.X * Axis.X * (1.0f - CosTheta)) + CosTheta;
+    Result.Elements[0][1] = (Axis.X * Axis.Y * (1.0f - CosTheta)) - (Axis.Z * SinTheta);
+    Result.Elements[0][2] = (Axis.X * Axis.Z * (1.0f - CosTheta)) + (Axis.Y * SinTheta);
+    
+    Result.Elements[1][0] = (Axis.X * Axis.Y * (1.0f - CosTheta)) + (Axis.Z * SinTheta);
+    Result.Elements[1][1] = (Axis.Y * Axis.Y * (1.0f - CosTheta)) + CosTheta;
+    Result.Elements[1][2] = (Axis.Y * Axis.Z * (1.0f - CosTheta)) - (Axis.X * SinTheta);
+    
+    Result.Elements[2][0] = (Axis.X * Axis.Z * (1.0f - CosTheta)) - (Axis.Y * SinTheta);
+    Result.Elements[2][1] = (Axis.Y * Axis.Z * (1.0f - CosTheta)) + (Axis.X * SinTheta);
+    Result.Elements[2][2] = (Axis.Z * Axis.Z * (1.0f - CosTheta)) + CosTheta);
+    
     return (Result);
 }
 

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -808,7 +808,7 @@ HMM_Rotate(float Angle, hmm_vec3 Axis)
     float CosTheta = cosf(HMM_ToRadians(Angle));
     float CosValue = 1.0f - CosTheta;
     
-    Result.Elements[0][0] = (Axis.X * Axis.X * CosValue + CosTheta;
+    Result.Elements[0][0] = (Axis.X * Axis.X * CosValue) + CosTheta;
     Result.Elements[0][1] = (Axis.X * Axis.Y * CosValue) - (Axis.Z * SinTheta);
     Result.Elements[0][2] = (Axis.X * Axis.Z * CosValue) + (Axis.Y * SinTheta);
     

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -773,13 +773,11 @@ HMM_Perspective(float FOV, float AspectRatio, float Near, float Far)
 {
     hmm_mat4 Result = HMM_Mat4d(1.0f);
 
-    float TanThetaOver2 = tanf(FOV * (HMM_PI32 / 360.0f));
-    
-    Result.Elements[0][0] = 1.0f / TanThetaOver2;
-    Result.Elements[1][1] = AspectRatio / TanThetaOver2;
+    Result.Elements[0][0] = 1.0f / (AspectRatio * tanf(FOV / 2.0f));
+    Result.Elements[1][1] = 1.0f / tanf(FOV / 2.0f);
     Result.Elements[2][3] = -1.0f;
-    Result.Elements[2][2] = (Near + Far) / (Near - Far);
-    Result.Elements[3][2] = (2.0f * Near * Far) / (Near - Far);
+    Result.Elements[2][2] = -(Far + Near) / (Far - Near);
+    Result.Elements[3][2] = -(2.0f * Far * Near) / (Far - Near);
     Result.Elements[3][3] = 0.0f;
 
     return (Result);

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -801,8 +801,8 @@ HMM_Rotate(float Angle, hmm_vec3 Axis)
 {
     hmm_mat4 Result = HMM_Mat4d(1.0f);
     
-    SinTheta = sinf(HMM_ToRadians(Angle));
-    CosTheta = cosf(HMM_ToRadians(Angle));
+    float SinTheta = sinf(HMM_ToRadians(Angle));
+    float CosTheta = cosf(HMM_ToRadians(Angle));
     
     Result.Elements[0][0] = (Axis.X * Axis.X * (1.0f - CosTheta)) + CosTheta;
     Result.Elements[0][1] = (Axis.X * Axis.Y * (1.0f - CosTheta)) - (Axis.Z * SinTheta);

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -352,6 +352,7 @@ HMM_LengthSquareRoot(hmm_vec3 A)
     return (Result);
 }
 
+// Refer to https://en.wikipedia.org/wiki/Fast_inverse_square_root
 HINLINE float
 HMM_FastInverseSquareRoot(float Number)
 {

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -806,7 +806,7 @@ HMM_Rotate(float Angle, hmm_vec3 Axis)
     float CosTheta = cosf(HMM_ToRadians(Angle));
     float CosValue = 1.0f - CosTheta;
     
-    Result.Elements[0][0] = (Axis.X * Axis.X * CosValue + CosTheta;
+    Result.Elements[0][0] = (Axis.X * Axis.X * CosValue) + CosTheta;
     Result.Elements[0][1] = (Axis.X * Axis.Y * CosValue) - (Axis.Z * SinTheta);
     Result.Elements[0][2] = (Axis.X * Axis.Z * CosValue) + (Axis.Y * SinTheta);
     

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -773,11 +773,13 @@ HMM_Perspective(float FOV, float AspectRatio, float Near, float Far)
 {
     hmm_mat4 Result = HMM_Mat4d(1.0f);
 
-    Result.Elements[0][0] = 1.0f / (AspectRatio * tanf(FOV / 2.0f));
-    Result.Elements[1][1] = 1.0f / tanf(FOV / 2.0f);
+    float TanThetaOver2 = tanf(FOV * (HMM_PI32 / 360.0f));
+    
+    Result.Elements[0][0] = 1.0f / TanThetaOver2;
+    Result.Elements[1][1] = AspectRatio / TanThetaOver2;
     Result.Elements[2][3] = -1.0f;
-    Result.Elements[2][2] = -(Far + Near) / (Far - Near);
-    Result.Elements[3][2] = -(2.0f * Far * Near) / (Far - Near);
+    Result.Elements[2][2] = (Near + Far) / (Near - Far);
+    Result.Elements[3][2] = (2.0f * Near * Far) / (Near - Far);
     Result.Elements[3][3] = 0.0f;
 
     return (Result);

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -84,7 +84,7 @@ extern "C"
 #endif
 
 #define HMM_PI32 3.14159265359f
-#define HMM_PI 3.14159265358979323846
+#define HMM_PI 3.14159265358979323846f
 
 #define HMM_MIN(a, b) (a) > (b) ? (b) : (a)
 #define HMM_MAX(a, b) (a) < (b) ? (b) : (a)

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -809,15 +809,15 @@ HMM_Rotate(float Angle, hmm_vec3 Axis)
     float CosValue = 1.0f - CosTheta;
     
     Result.Elements[0][0] = (Axis.X * Axis.X * CosValue) + CosTheta;
-    Result.Elements[0][1] = (Axis.X * Axis.Y * CosValue) - (Axis.Z * SinTheta);
-    Result.Elements[0][2] = (Axis.X * Axis.Z * CosValue) + (Axis.Y * SinTheta);
+    Result.Elements[0][1] = (Axis.X * Axis.Y * CosValue) + (Axis.Z * SinTheta);
+    Result.Elements[0][2] = (Axis.X * Axis.Z * CosValue) - (Axis.Y * SinTheta);
     
-    Result.Elements[1][0] = (Axis.Y * Axis.X * CosValue) + (Axis.Z * SinTheta);
+    Result.Elements[1][0] = (Axis.Y * Axis.X * CosValue) - (Axis.Z * SinTheta);
     Result.Elements[1][1] = (Axis.Y * Axis.Y * CosValue) + CosTheta;
-    Result.Elements[1][2] = (Axis.Y * Axis.Z * CosValue) - (Axis.X * SinTheta);
+    Result.Elements[1][2] = (Axis.Y * Axis.Z * CosValue) + (Axis.X * SinTheta);
     
-    Result.Elements[2][0] = (Axis.Z * Axis.X * CosValue) - (Axis.Y * SinTheta);
-    Result.Elements[2][1] = (Axis.Z * Axis.Y * CosValue) + (Axis.X * SinTheta);
+    Result.Elements[2][0] = (Axis.Z * Axis.X * CosValue) + (Axis.Y * SinTheta);
+    Result.Elements[2][1] = (Axis.Z * Axis.Y * CosValue) - (Axis.X * SinTheta);
     Result.Elements[2][2] = (Axis.Z * Axis.Z * CosValue) + CosTheta;
     
     return (Result);

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -773,13 +773,13 @@ HMM_Perspective(float FOV, float AspectRatio, float Near, float Far)
 {
     hmm_mat4 Result = HMM_Mat4d(1.0f);
 
-    float TanThetaOver2 = tanf(FOV / 2.0f);
+    float TanThetaOver2 = tanf(FOV * (HMM_PI32 / 360.0f));
     
-    Result.Elements[0][0] = 1.0f / (AspectRatio * TanThetaOver2);
-    Result.Elements[1][1] = 1.0f / TanThetaOver2;
+    Result.Elements[0][0] = 1.0f / TanThetaOver2;
+    Result.Elements[1][1] = AspectRatio / TanThetaOver2;
     Result.Elements[2][3] = -1.0f;
-    Result.Elements[2][2] = -(Far + Near) / (Far - Near);
-    Result.Elements[3][2] = -(2.0f * Far * Near) / (Far - Near);
+    Result.Elements[2][2] = (Near + Far) / (Near - Far);
+    Result.Elements[3][2] = (2.0f * Near * Far) / (Near - Far);
     Result.Elements[3][3] = 0.0f;
 
     return (Result);

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -773,8 +773,10 @@ HMM_Perspective(float FOV, float AspectRatio, float Near, float Far)
 {
     hmm_mat4 Result = HMM_Mat4d(1.0f);
 
-    Result.Elements[0][0] = 1.0f / (AspectRatio * tanf(FOV / 2.0f));
-    Result.Elements[1][1] = 1.0f / tanf(FOV / 2.0f);
+    float TanThetaOver2 = tanf(FOV / 2.0f);
+    
+    Result.Elements[0][0] = 1.0f / (AspectRatio * TanThetaOver2);
+    Result.Elements[1][1] = 1.0f / TanThetaOver2;
     Result.Elements[2][3] = -1.0f;
     Result.Elements[2][2] = -(Far + Near) / (Far - Near);
     Result.Elements[3][2] = -(2.0f * Far * Near) / (Far - Near);
@@ -804,7 +806,7 @@ HMM_Rotate(float Angle, hmm_vec3 Axis)
     float CosTheta = cosf(HMM_ToRadians(Angle));
     float CosValue = 1.0f - CosTheta;
     
-    Result.Elements[0][0] = (Axis.X * Axis.X * CosValue) + CosTheta;
+    Result.Elements[0][0] = (Axis.X * Axis.X * CosValue + CosTheta;
     Result.Elements[0][1] = (Axis.X * Axis.Y * CosValue) - (Axis.Z * SinTheta);
     Result.Elements[0][2] = (Axis.X * Axis.Z * CosValue) + (Axis.Y * SinTheta);
     


### PR DESCRIPTION
- Added f suffix to HMM_PI to follow the float convention used throughout the code.

- For HMM_Rotate, I precomputed Sin theta and Cos theta into variables because there's no point wasting CPU time computing them more than once. Did the same for 1.0f - CosTheta, because it's used many times. Makes the code more readable, too, as a benefit. :)

- Also for HMM_Rotate, the viewport result was looking stretched: the Axis needed to be normalized first. GLM's code helped give me this clue.

- Added a Wikipedia reference for HMM_FastInverseSquareRoot, for those who may be confused by the code.

And my commit history is all over the place... :P :/ :(