### PR TITLE
Lots of improvements

### DIFF
--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -1,9 +1,11 @@
 /*
-  HandmadeMath.h v0.4
+  HandmadeMath.h v0.5
 
   This is a single header file with a bunch of useful functions for
   basic game math operations.
+
   ==========================================================================
+
   You MUST
 
      #define HANDMADE_MATH_IMPLEMENTATION
@@ -15,12 +17,13 @@
      #include "HandmadeMath.h"
 
   All other files should just #include "HandmadeMath.h" without the #define.
+
   ==========================================================================
 
-  For overloaded, and operator overloaded versions of the base C functions.
-  You MUST
+  For overloaded and operator overloaded versions of the base C functions,
+  you MUST
 
-  #define HANDMADE_MATH_CPP_MODE
+     #define HANDMADE_MATH_CPP_MODE
 
   in EXACTLY one C or C++ file that includes this header, BEFORE the
   include, like this:
@@ -30,9 +33,10 @@
      #include "HandmadeMath.h"
 
   All other files should just #include "HandmadeMath.h" without the #define.
+
   ==========================================================================
 
-  To disable SSE intrinsics, for You MUST
+  To disable SSE intrinsics, you MUST
 
   #define HANDMADE_MATH_NO_SSE
 
@@ -48,6 +52,7 @@
 
      #define HANDMADE_MATH_IMPLEMENTATION
      #define HANDMADE_MATH_NO_SSE
+     #include "HandmadeMath.h"
 
   ==========================================================================
 
@@ -69,23 +74,23 @@
   
   To Disable the CRT, you MUST 
 
-  #define HMM_SINF MySinF
-  #define HMM_COSF MyCosF
-  #define HMM_TANF MyTanF 
+     #define HMM_SINF MySinF
+     #define HMM_COSF MyCosF
+     #define HMM_TANF MyTanF
   
   Provide your own implementations of SinF, CosF, and TanF 
   in EXACTLY one C or C++ file that includes this header, BEFORE the
   include, like this:     
 
-  #define HMM_SINF MySinF
-  #define HMM_COSF MyCosF
-  #define HMM_TANF MyTanF 
-  #define HANDMADE_MATH_IMPLEMENTATION
-  #define HANDMADE_MATH_CPP_MODE   
-  #include "HandmadeMath.h"
+     #define HMM_SINF MySinF
+     #define HMM_COSF MyCosF
+     #define HMM_TANF MyTanF
+     #define HANDMADE_MATH_IMPLEMENTATION
+     #define HANDMADE_MATH_CPP_MODE
+     #include "HandmadeMath.h"
 
-  If you do not define these HandmadeMath.h will use version the version
-  of these function that are provided by the CRT.
+  If you do not define all three of these, HandmadeMath.h will use the
+  versions of these functions that are provided by the CRT.
 
   ==========================================================================
 
@@ -100,11 +105,18 @@
           (*) Disabled warning 4201 on MSVC as it is legal is C11
           (*) Removed the f at the end of HMM_PI to get 64bit precision
       0.3
-          (*) Added +=,-=, *=, /= for hmm_vec2, hmm_vec3, hmm_vec4
+          (*) Added +=, -=, *=, /= for hmm_vec2, hmm_vec3, hmm_vec4
       0.4
           (*) SSE Optimized HMM_SqrtF
           (*) SSE Optimized HMM_RSqrtF
           (*) Removed CRT
+      0.5
+          (*) Added scalar multiplication and division for vectors
+              and matrices
+          (*) Added matrix subtraction and += for hmm_mat4
+          (*) Reconciled all headers and implementations
+          (*) Tidied up, and filled in a few missing operators
+
 
 
   LICENSE

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -476,27 +476,24 @@ HMMDEF hmm_mat4 & operator/=(hmm_mat4 &Left, float Right);
 HINLINE float 
 HMM_SinF(float Angle)
 {
-    float Result = 0;
-    
-    Result = HMM_SINF(Angle);
+    float Result = HMM_SINF(Angle);
+
     return(Result);
 }
 
 HINLINE float 
 HMM_CosF(float Angle)
 {
-    float Result = 0;
-    
-    Result = HMM_COSF(Angle);
+    float Result = HMM_COSF(Angle);
+
     return(Result);
 }
 
 HINLINE float 
 HMM_TanF(float Radians)
 {
-    float Result = 0;
-    
-    Result = HMM_TANF(Radians);
+    float Result = HMM_TANF(Radians);
+
     return(Result);
 }
 
@@ -504,6 +501,7 @@ HINLINE float
 HMM_SqrtF(float Value)
 {
     float Result = 0;
+
 #ifdef HANDMADE_MATH_NO_SSE
     Result = sqrtf(Value);
 #else        
@@ -511,6 +509,7 @@ HMM_SqrtF(float Value)
     __m128 Out = _mm_sqrt_ss(In);
     _mm_store_ss(&Result, Out);
 #endif 
+
     return(Result);
 }
 
@@ -518,13 +517,15 @@ HINLINE float
 HMM_RSqrtF(float Value)
 {
     float Result = 0;
+
 #ifdef HANDMADE_MATH_NO_SSE
     Result = 1.0f/HMM_SqrtF(Value);    
 #else        
     __m128 In = _mm_load_ss(&Value);
     __m128 Out = _mm_rsqrt_ss(In);
     _mm_store_ss(&Result, Out);
-#endif     
+#endif
+
     return(Result);
 }
 
@@ -556,6 +557,7 @@ HINLINE float
 HMM_Length(hmm_vec3 A)
 {
     float Result = HMM_SqrtF(HMM_LengthSquareRoot(A));
+
     return (Result);
 }
 
@@ -563,6 +565,7 @@ HINLINE float
 HMM_Power(float Base, int Exponent)
 {
     float Result = 1;
+
     if(Exponent > 0)
     {
         int i;
@@ -579,6 +582,7 @@ HMM_Power(float Base, int Exponent)
             Result /= Base;
         }
     }
+
     return (Result);
 }
 
@@ -623,7 +627,7 @@ HMM_Normalize(hmm_vec3 A)
 HINLINE hmm_vec3
 HMM_Cross(hmm_vec3 VecOne, hmm_vec3 VecTwo)
 {
-    hmm_vec3 Result;
+    hmm_vec3 Result = {0};
 
     Result.X = (VecOne.Y * VecTwo.Z) - (VecOne.Z * VecTwo.Y);
     Result.Y = (VecOne.Z * VecTwo.X) - (VecOne.X * VecTwo.Z);
@@ -645,7 +649,7 @@ HMM_Dot(hmm_vec3 VecOne, hmm_vec3 VecTwo)
 HINLINE hmm_vec2
 HMM_Vec2(float X, float Y)
 {
-    hmm_vec2 Result;
+    hmm_vec2 Result = {0};
 
     Result.X = X;
     Result.Y = Y;
@@ -656,7 +660,7 @@ HMM_Vec2(float X, float Y)
 HINLINE hmm_vec2
 HMM_Vec2i(int X, int Y)
 {
-    hmm_vec2 Result;
+    hmm_vec2 Result = {0};
 
     Result.X = (float)X;
     Result.Y = (float)Y;
@@ -667,7 +671,7 @@ HMM_Vec2i(int X, int Y)
 HINLINE hmm_vec3
 HMM_Vec3(float X, float Y, float Z)
 {
-    hmm_vec3 Result;
+    hmm_vec3 Result = {0};
 
     Result.X = X;
     Result.Y = Y;
@@ -679,7 +683,7 @@ HMM_Vec3(float X, float Y, float Z)
 HINLINE hmm_vec3
 HMM_Vec3i(int X, int Y, int Z)
 {
-    hmm_vec3 Result;
+    hmm_vec3 Result = {0};
 
     Result.X = (float)X;
     Result.Y = (float)Y;
@@ -691,7 +695,7 @@ HMM_Vec3i(int X, int Y, int Z)
 HINLINE hmm_vec4
 HMM_Vec4(float X, float Y, float Z, float W)
 {
-    hmm_vec4 Result;
+    hmm_vec4 Result = {0};
 
     Result.X = X;
     Result.Y = Y;
@@ -704,7 +708,7 @@ HMM_Vec4(float X, float Y, float Z, float W)
 HINLINE hmm_vec4
 HMM_Vec4i(int X, int Y, int Z, int W)
 {
-    hmm_vec4 Result;
+    hmm_vec4 Result = {0};
 
     Result.X = (float)X;
     Result.Y = (float)Y;
@@ -717,7 +721,7 @@ HMM_Vec4i(int X, int Y, int Z, int W)
 HINLINE hmm_vec4
 HMM_Vec4v(hmm_vec3 Vector, float W)
 {
-    hmm_vec4 Result;
+    hmm_vec4 Result = {0};
 
     Result.XYZ = Vector;
     Result.W = W;
@@ -728,7 +732,7 @@ HMM_Vec4v(hmm_vec3 Vector, float W)
 HINLINE hmm_vec2
 HMM_AddVec2(hmm_vec2 Left, hmm_vec2 Right)
 {
-    hmm_vec2 Result;
+    hmm_vec2 Result = {0};
 
     Result.X = Left.X + Right.X;
     Result.Y = Left.Y + Right.Y;
@@ -739,7 +743,7 @@ HMM_AddVec2(hmm_vec2 Left, hmm_vec2 Right)
 HINLINE hmm_vec3
 HMM_AddVec3(hmm_vec3 Left, hmm_vec3 Right)
 {
-    hmm_vec3 Result;
+    hmm_vec3 Result = {0};
 
     Result.X = Left.X + Right.X;
     Result.Y = Left.Y + Right.Y;
@@ -751,7 +755,7 @@ HMM_AddVec3(hmm_vec3 Left, hmm_vec3 Right)
 HINLINE hmm_vec4
 HMM_AddVec4(hmm_vec4 Left, hmm_vec4 Right)
 {
-    hmm_vec4 Result;
+    hmm_vec4 Result = {0};
 
     Result.X = Left.X + Right.X;
     Result.Y = Left.Y + Right.Y;
@@ -764,7 +768,7 @@ HMM_AddVec4(hmm_vec4 Left, hmm_vec4 Right)
 HINLINE hmm_vec2
 HMM_SubtractVec2(hmm_vec2 Left, hmm_vec2 Right)
 {
-    hmm_vec2 Result;
+    hmm_vec2 Result = {0};
 
     Result.X = Left.X - Right.X;
     Result.Y = Left.Y - Right.Y;
@@ -775,7 +779,7 @@ HMM_SubtractVec2(hmm_vec2 Left, hmm_vec2 Right)
 HINLINE hmm_vec3
 HMM_SubtractVec3(hmm_vec3 Left, hmm_vec3 Right)
 {
-    hmm_vec3 Result;
+    hmm_vec3 Result = {0};
 
     Result.X = Left.X - Right.X;
     Result.Y = Left.Y - Right.Y;
@@ -787,7 +791,7 @@ HMM_SubtractVec3(hmm_vec3 Left, hmm_vec3 Right)
 HINLINE hmm_vec4
 HMM_SubtractVec4(hmm_vec4 Left, hmm_vec4 Right)
 {
-    hmm_vec4 Result;
+    hmm_vec4 Result = {0};
 
     Result.X = Left.X - Right.X;
     Result.Y = Left.Y - Right.Y;
@@ -800,7 +804,7 @@ HMM_SubtractVec4(hmm_vec4 Left, hmm_vec4 Right)
 HINLINE hmm_vec2
 HMM_MultiplyVec2(hmm_vec2 Left, hmm_vec2 Right)
 {
-    hmm_vec2 Result;
+    hmm_vec2 Result = {0};
 
     Result.X = Left.X * Right.X;
     Result.Y = Left.Y * Right.Y;
@@ -811,7 +815,7 @@ HMM_MultiplyVec2(hmm_vec2 Left, hmm_vec2 Right)
 HINLINE hmm_vec2
 HMM_MultiplyVec2f(hmm_vec2 Left, float Right)
 {
-    hmm_vec2 Result;
+    hmm_vec2 Result = {0};
 
     Result.X = Left.X * Right;
     Result.Y = Left.Y * Right;
@@ -822,7 +826,7 @@ HMM_MultiplyVec2f(hmm_vec2 Left, float Right)
 HINLINE hmm_vec3
 HMM_MultiplyVec3(hmm_vec3 Left, hmm_vec3 Right)
 {
-    hmm_vec3 Result;
+    hmm_vec3 Result = {0};
 
     Result.X = Left.Z * Right.X;
     Result.Y = Left.Y * Right.Y;
@@ -834,7 +838,7 @@ HMM_MultiplyVec3(hmm_vec3 Left, hmm_vec3 Right)
 HINLINE hmm_vec3
 HMM_MultiplyVec3f(hmm_vec3 Left, float Right)
 {
-    hmm_vec3 Result;
+    hmm_vec3 Result = {0};
 
     Result.X = Left.X * Right;
     Result.Y = Left.Y * Right;
@@ -846,7 +850,7 @@ HMM_MultiplyVec3f(hmm_vec3 Left, float Right)
 HINLINE hmm_vec4
 HMM_MultiplyVec4(hmm_vec4 Left, hmm_vec4 Right)
 {
-    hmm_vec4 Result;
+    hmm_vec4 Result = {0};
 
     Result.X = Left.X * Right.X;
     Result.Y = Left.Y * Right.Y;
@@ -859,7 +863,7 @@ HMM_MultiplyVec4(hmm_vec4 Left, hmm_vec4 Right)
 HINLINE hmm_vec4
 HMM_MultiplyVec4f(hmm_vec4 Left, float Right)
 {
-    hmm_vec4 Result;
+    hmm_vec4 Result = {0};
 
     Result.X = Left.X * Right;
     Result.Y = Left.Y * Right;
@@ -872,7 +876,7 @@ HMM_MultiplyVec4f(hmm_vec4 Left, float Right)
 HINLINE hmm_vec2
 HMM_DivideVec2(hmm_vec2 Left, hmm_vec2 Right)
 {
-    hmm_vec2 Result;
+    hmm_vec2 Result = {0};
 
     Result.X = Left.X / Right.X;
     Result.Y = Left.Y / Right.Y;
@@ -883,7 +887,7 @@ HMM_DivideVec2(hmm_vec2 Left, hmm_vec2 Right)
 HINLINE hmm_vec2
 HMM_DivideVec2f(hmm_vec2 Left, float Right)
 {
-    hmm_vec2 Result;
+    hmm_vec2 Result = {0};
 
     Result.X = Left.X / Right;
     Result.Y = Left.Y / Right;
@@ -894,7 +898,7 @@ HMM_DivideVec2f(hmm_vec2 Left, float Right)
 HINLINE hmm_vec3
 HMM_DivideVec3(hmm_vec3 Left, hmm_vec3 Right)
 {
-    hmm_vec3 Result;
+    hmm_vec3 Result = {0};
 
     Result.X = Left.X / Right.X;
     Result.Y = Left.Y / Right.Y;
@@ -906,7 +910,7 @@ HMM_DivideVec3(hmm_vec3 Left, hmm_vec3 Right)
 HINLINE hmm_vec3
 HMM_DivideVec3f(hmm_vec3 Left, float Right)
 {
-    hmm_vec3 Result;
+    hmm_vec3 Result = {0};
 
     Result.X = Left.X / Right;
     Result.Y = Left.Y / Right;
@@ -918,7 +922,7 @@ HMM_DivideVec3f(hmm_vec3 Left, float Right)
 HINLINE hmm_vec4
 HMM_DivideVec4(hmm_vec4 Left, hmm_vec4 Right)
 {
-    hmm_vec4 Result;
+    hmm_vec4 Result = {0};
 
     Result.X = Left.X / Right.X;
     Result.Y = Left.Y / Right.Y;
@@ -931,7 +935,7 @@ HMM_DivideVec4(hmm_vec4 Left, hmm_vec4 Right)
 HINLINE hmm_vec4
 HMM_DivideVec4f(hmm_vec4 Left, float Right)
 {
-    hmm_vec4 Result;
+    hmm_vec4 Result = {0};
 
     Result.X = Left.X / Right;
     Result.Y = Left.Y / Right;
@@ -952,7 +956,7 @@ HMM_Mat4()
 hmm_mat4
 HMM_Mat4d(float Diagonal)
 {
-    hmm_mat4 Result;
+    hmm_mat4 Result = HMM_Mat4();
 
     int Rows;
     for(Rows = 0; Rows < 4; ++Rows)
@@ -975,7 +979,7 @@ HMM_Mat4d(float Diagonal)
 HINLINE hmm_mat4
 HMM_AddMat4(hmm_mat4 Left, hmm_mat4 Right)
 {
-    hmm_mat4 Result;
+    hmm_mat4 Result = HMM_Mat4();
 
     int Rows;
     for (Rows = 0; Rows < 4; ++Rows)
@@ -993,7 +997,7 @@ HMM_AddMat4(hmm_mat4 Left, hmm_mat4 Right)
 HINLINE hmm_mat4
 HMM_SubtractMat4(hmm_mat4 Left, hmm_mat4 Right)
 {
-    hmm_mat4 Result;
+    hmm_mat4 Result = HMM_Mat4();
 
     int Rows;
     for (Rows = 0; Rows < 4; ++Rows)
@@ -1036,7 +1040,7 @@ HMM_MultiplyMat4(hmm_mat4 Left, hmm_mat4 Right)
 hmm_mat4
 HMM_MultiplyMat4f(hmm_mat4 Matrix, float Scalar)
 {
-    hmm_mat4 Result;
+    hmm_mat4 Result = HMM_Mat4();
 
     int Rows;
     for (Rows = 0; Rows < 4; ++Rows)
@@ -1054,7 +1058,7 @@ HMM_MultiplyMat4f(hmm_mat4 Matrix, float Scalar)
 hmm_vec4
 HMM_MultiplyMat4ByVec4(hmm_mat4 Matrix, hmm_vec4 Vector)
 {
-    hmm_vec4 Result = HMM_Vec4(0.0f, 0.0f, 0.0f, 0.0f);
+    hmm_vec4 Result = {0};
     
     int Rows, Columns;
     for(Rows = 0; Rows < 4; ++Rows)
@@ -1074,7 +1078,7 @@ HMM_MultiplyMat4ByVec4(hmm_mat4 Matrix, hmm_vec4 Vector)
 hmm_mat4
 HMM_DivideMat4f(hmm_mat4 Matrix, float Scalar)
 {
-    hmm_mat4 Result;
+    hmm_mat4 Result = HMM_Mat4();
 
     int Rows;
     for (Rows = 0; Rows < 4; ++Rows)

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -486,25 +486,28 @@ HMMDEF hmm_mat4 & operator/=(hmm_mat4 &Left, float Right);
 HINLINE float 
 HMM_SinF(float Angle)
 {
-    float Result = HMM_SINF(Angle);
+    float Result = 0;
 
-    return(Result);
+    Result = HMM_SINF(Angle);
+    return (Result);
 }
 
 HINLINE float 
 HMM_CosF(float Angle)
 {
-    float Result = HMM_COSF(Angle);
+    float Result = 0;
 
-    return(Result);
+    Result = HMM_COSF(Angle);
+    return (Result);
 }
 
 HINLINE float 
 HMM_TanF(float Radians)
 {
-    float Result = HMM_TANF(Radians);
+    float Result = 0;
 
-    return(Result);
+    Result = HMM_TANF(Radians);
+    return (Result);
 }
 
 HINLINE float 
@@ -542,32 +545,36 @@ HMM_RSqrtF(float Value)
 HINLINE float
 HMM_ToRadians(float Degrees)
 {
-    float Result = Degrees * (HMM_PI32 / 180.0f);
+    float Result = 0;
 
+    Result = Degrees * (HMM_PI32 / 180.0f);
     return (Result);
 }
 
 HINLINE float
 HMM_Inner(hmm_vec3 A, hmm_vec3 B)
 {
-    float Result = A.X * B.X + A.Y * B.Y + A.Z * B.Z;
+    float Result = 0;
 
+    Result = A.X * B.X + A.Y * B.Y + A.Z * B.Z;
     return (Result);
 }
 
 HINLINE float
 HMM_LengthSquareRoot(hmm_vec3 A)
 {
-    float Result = HMM_Inner(A, A);
+    float Result = 0;
 
+    Result = HMM_Inner(A, A);
     return (Result);
 }
 
 HINLINE float
 HMM_Length(hmm_vec3 A)
 {
-    float Result = HMM_SqrtF(HMM_LengthSquareRoot(A));
+    float Result = 0;
 
+    Result = HMM_SqrtF(HMM_LengthSquareRoot(A));
     return (Result);
 }
 
@@ -599,8 +606,9 @@ HMM_Power(float Base, int Exponent)
 HINLINE float
 HMM_Lerp(float A, float Time, float B)
 {
-    float Result = (1.0f - Time) * A + Time * B;
+    float Result = 0;
 
+    Result = (1.0f - Time) * A + Time * B;
     return (Result);
 }
 
@@ -652,7 +660,6 @@ HMM_Dot(hmm_vec3 VecOne, hmm_vec3 VecTwo)
     float Result = 0;
 
     Result = (VecOne.X * VecTwo.X) + (VecOne.Y * VecTwo.Y) + (VecOne.Z * VecTwo.Z);
-
     return (Result);
 }
 
@@ -1220,272 +1227,306 @@ HMM_Scale(hmm_vec3 Scale)
 HINLINE hmm_vec2
 HMM_Add(hmm_vec2 Left, hmm_vec2 Right)
 {
-    hmm_vec2 Result = HMM_AddVec2(Left, Right);
+    hmm_vec2 Result = {0};
 
+    Result = HMM_AddVec2(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec3
 HMM_Add(hmm_vec3 Left, hmm_vec3 Right)
 {
-    hmm_vec3 Result = HMM_AddVec3(Left, Right);
+    hmm_vec3 Result = {0};
 
+    Result = HMM_AddVec3(Left, Right);
     return (Result);
 }
 
 HMMDEF HINLINE hmm_vec4
 HMM_Add(hmm_vec4 Left, hmm_vec4 Right)
 {
-    hmm_vec4 Result = HMM_AddVec4(Left, Right);
+    hmm_vec4 Result = {0};
 
+    Result = HMM_AddVec4(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_mat4
 HMM_Add(hmm_mat4 Left, hmm_mat4 Right)
 {
-    hmm_mat4 Result = HMM_AddMat4(Left, Right);
+    hmm_mat4 Result = {0};
 
+    Result = HMM_AddMat4(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec2
 HMM_Subtract(hmm_vec2 Left, hmm_vec2 Right)
 {
-    hmm_vec2 Result = HMM_SubtractVec2(Left, Right);
+    hmm_vec2 Result = {0};
 
+    Result = HMM_SubtractVec2(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec3
 HMM_Subtract(hmm_vec3 Left, hmm_vec3 Right)
 {
-    hmm_vec3 Result = HMM_SubtractVec3(Left, Right);
+    hmm_vec3 Result = {0};
 
+    Result = HMM_SubtractVec3(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec4
 HMM_Subtract(hmm_vec4 Left, hmm_vec4 Right)
 {
-    hmm_vec4 Result = HMM_SubtractVec4(Left, Right);
+    hmm_vec4 Result = {0};
 
+    Result = HMM_SubtractVec4(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_mat4
 HMM_Subtract(hmm_mat4 Left, hmm_mat4 Right)
 {
-    hmm_mat4 Result = HMM_SubtractMat4(Left, Right);
+    hmm_mat4 Result = {0};
 
+    Result = HMM_SubtractMat4(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec2
 HMM_Multiply(hmm_vec2 Left, hmm_vec2 Right)
 {
-    hmm_vec2 Result = HMM_MultiplyVec2(Left, Right);
+    hmm_vec2 Result = {0};
 
+    Result = HMM_MultiplyVec2(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec2
 HMM_Multiply(hmm_vec2 Left, float Right)
 {
-    hmm_vec2 Result = HMM_MultiplyVec2f(Left, Right);
+    hmm_vec2 Result = {0};
 
+    Result = HMM_MultiplyVec2f(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec3
 HMM_Multiply(hmm_vec3 Left, hmm_vec3 Right)
 {
-    hmm_vec3 Result = HMM_MultiplyVec3(Left, Right);
+    hmm_vec3 Result = {0};
 
+    Result = HMM_MultiplyVec3(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec3
 HMM_Multiply(hmm_vec3 Left, float Right)
 {
-    hmm_vec3 Result = HMM_MultiplyVec3f(Left, Right);
+    hmm_vec3 Result = {0};
 
+    Result = HMM_MultiplyVec3f(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec4
 HMM_Multiply(hmm_vec4 Left, hmm_vec4 Right)
 {
-    hmm_vec4 Result = HMM_MultiplyVec4(Left, Right);
+    hmm_vec4 Result = {0};
 
+    Result = HMM_MultiplyVec4(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec4
 HMM_Multiply(hmm_vec4 Left, float Right)
 {
-    hmm_vec4 Result = HMM_MultiplyVec4f(Left, Right);
+    hmm_vec4 Result = {0};
 
+    Result = HMM_MultiplyVec4f(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_mat4
 HMM_Multiply(hmm_mat4 Left, hmm_mat4 Right)
 {
-    hmm_mat4 Result = HMM_MultiplyMat4(Left, Right);
+    hmm_mat4 Result = {0};
 
+    Result = HMM_MultiplyMat4(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_mat4
 HMM_Multiply(hmm_mat4 Left, float Right)
 {
-    hmm_mat4 Result = HMM_MultiplyMat4f(Left, Right);
+    hmm_mat4 Result = {0};
 
+    Result = HMM_MultiplyMat4f(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec4
 HMM_Multiply(hmm_mat4 Matrix, hmm_vec4 Vector)
 {
-    hmm_vec4 Result = HMM_MultiplyMat4ByVec4(Matrix, Vector);
-    
+    hmm_vec4 Result = {0};
+
+    Result = HMM_MultiplyMat4ByVec4(Matrix, Vector);
     return (Result);
 }
 
 HINLINE hmm_vec2
 HMM_Divide(hmm_vec2 Left, hmm_vec2 Right)
 {
-    hmm_vec2 Result = HMM_DivideVec2(Left, Right);
+    hmm_vec2 Result = {0};
 
+    Result = HMM_DivideVec2(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec2
 HMM_Divide(hmm_vec2 Left, float Right)
 {
-    hmm_vec2 Result = HMM_DivideVec2f(Left, Right);
+    hmm_vec2 Result = {0};
 
+    Result = HMM_DivideVec2f(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec3
 HMM_Divide(hmm_vec3 Left, hmm_vec3 Right)
 {
-    hmm_vec3 Result = HMM_DivideVec3(Left, Right);
+    hmm_vec3 Result = {0};
 
+    Result = HMM_DivideVec3(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec3
 HMM_Divide(hmm_vec3 Left, float Right)
 {
-    hmm_vec3 Result = HMM_DivideVec3f(Left, Right);
+    hmm_vec3 Result = {0};
 
+    Result = HMM_DivideVec3f(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec4
 HMM_Divide(hmm_vec4 Left, hmm_vec4 Right)
 {
-    hmm_vec4 Result = HMM_DivideVec4(Left, Right);
+    hmm_vec4 Result = {0};
 
+    Result = HMM_DivideVec4(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec4
 HMM_Divide(hmm_vec4 Left, float Right)
 {
-    hmm_vec4 Result = HMM_DivideVec4f(Left, Right);
+    hmm_vec4 Result = {0};
 
+    Result = HMM_DivideVec4f(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_mat4
 HMM_Divide(hmm_mat4 Left, float Right)
 {
-    hmm_mat4 Result = HMM_DivideMat4f(Left, Right);
+    hmm_mat4 Result = {0};
 
+    Result = HMM_DivideMat4f(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec2
 operator+(hmm_vec2 Left, hmm_vec2 Right)
 {
-    hmm_vec2 Result = HMM_Add(Left, Right);
+    hmm_vec2 Result = {0};
 
+    Result = HMM_Add(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec3
 operator+(hmm_vec3 Left, hmm_vec3 Right)
 {
-    hmm_vec3 Result = HMM_Add(Left, Right);
+    hmm_vec3 Result = {0};
 
+    Result = HMM_Add(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec4
 operator+(hmm_vec4 Left, hmm_vec4 Right)
 {
-    hmm_vec4 Result = HMM_Add(Left, Right);
+    hmm_vec4 Result = {0};
 
+    Result = HMM_Add(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_mat4
 operator+(hmm_mat4 Left, hmm_mat4 Right)
 {
-    hmm_mat4 Result = HMM_Add(Left, Right);
+    hmm_mat4 Result = {0};
 
+    Result = HMM_Add(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec2
 operator-(hmm_vec2 Left, hmm_vec2 Right)
 {
-    hmm_vec2 Result = HMM_Subtract(Left, Right);
+    hmm_vec2 Result = {0};
 
+    Result = HMM_Subtract(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec3
 operator-(hmm_vec3 Left, hmm_vec3 Right)
 {
-    hmm_vec3 Result = HMM_Subtract(Left, Right);
+    hmm_vec3 Result = {0};
 
+    Result = HMM_Subtract(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec4
 operator-(hmm_vec4 Left, hmm_vec4 Right)
 {
-    hmm_vec4 Result = HMM_Subtract(Left, Right);
+    hmm_vec4 Result = {0};
 
+    Result = HMM_Subtract(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_mat4
 operator-(hmm_mat4 Left, hmm_mat4 Right)
 {
-    hmm_mat4 Result = HMM_Subtract(Left, Right);
+    hmm_mat4 Result = {0};
 
+    Result = HMM_Subtract(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec2
 operator*(hmm_vec2 Left, hmm_vec2 Right)
 {
-    hmm_vec2 Result = HMM_Multiply(Left, Right);
+    hmm_vec2 Result = {0};
 
+    Result = HMM_Multiply(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec3
 operator*(hmm_vec3 Left, hmm_vec3 Right)
 {
-    hmm_vec3 Result = HMM_Multiply(Left, Right);
+    hmm_vec3 Result = {0};
 
+    Result = HMM_Multiply(Left, Right);
     return (Result);
 }
 
@@ -1500,88 +1541,99 @@ operator*(hmm_vec4 Left, hmm_vec4 Right)
 HINLINE hmm_vec2
 operator*(hmm_vec2 Left, float Right)
 {
-    hmm_vec2 Result = HMM_Multiply(Left, Right);
+    hmm_vec2 Result = {0};
 
+    Result = HMM_Multiply(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec3
 operator*(hmm_vec3 Left, float Right)
 {
-    hmm_vec3 Result = HMM_Multiply(Left, Right);
+    hmm_vec3 Result = {0};
 
+    Result = HMM_Multiply(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec4
 operator*(hmm_vec4 Left, float Right)
 {
-    hmm_vec4 Result = HMM_Multiply(Left, Right);
+    hmm_vec4 Result = {0};
 
+    Result = HMM_Multiply(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_mat4
 operator*(hmm_mat4 Left, float Right)
 {
-    hmm_mat4 Result = HMM_Multiply(Left, Right);
+    hmm_mat4 Result = {0};
 
+    Result = HMM_Multiply(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec2
 operator*(float Left, hmm_vec2 Right)
 {
-    hmm_vec2 Result = HMM_Multiply(Right, Left);
+    hmm_vec2 Result = {0};
 
+    Result = HMM_Multiply(Right, Left);
     return (Result);
 }
 
 HINLINE hmm_vec3
 operator*(float Left, hmm_vec3 Right)
 {
-    hmm_vec3 Result = HMM_Multiply(Right, Left);
+    hmm_vec3 Result = {0};
 
+    Result = HMM_Multiply(Right, Left);
     return (Result);
 }
 
 HINLINE hmm_vec4
 operator*(float Left, hmm_vec4 Right)
 {
-    hmm_vec4 Result = HMM_Multiply(Right, Left);
+    hmm_vec4 Result = {0};
 
+    Result = HMM_Multiply(Right, Left);
     return (Result);
 }
 
 HINLINE hmm_mat4
 operator*(float Left, hmm_mat4 Right)
 {
-    hmm_mat4 Result = HMM_Multiply(Right, Left);
+    hmm_mat4 Result = {0};
 
+    Result = HMM_Multiply(Right, Left);
     return (Result);
 }
 
 HINLINE hmm_mat4
 operator*(hmm_mat4 Left, hmm_mat4 Right)
 {
-    hmm_mat4 Result = HMM_Multiply(Left, Right);
+    hmm_mat4 Result = {0};
 
+    Result = HMM_Multiply(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec4
 operator*(hmm_mat4 Matrix, hmm_vec4 Vector)
 {
-    hmm_vec4 Result = HMM_Multiply(Matrix, Vector);
-    
+    hmm_vec4 Result = {0};
+
+    Result = HMM_Multiply(Matrix, Vector);
     return (Result);
 }
 
 HINLINE hmm_vec2
 operator/(hmm_vec2 Left, hmm_vec2 Right)
 {
-    hmm_vec2 Result = HMM_Divide(Left, Right);
+    hmm_vec2 Result = {0};
 
+    Result = HMM_Divide(Left, Right);
     return (Result);
 }
 
@@ -1596,173 +1648,178 @@ operator/(hmm_vec3 Left, hmm_vec3 Right)
 HINLINE hmm_vec4
 operator/(hmm_vec4 Left, hmm_vec4 Right)
 {
-    hmm_vec4 Result = HMM_Divide(Left, Right);
+    hmm_vec4 Result = {0};
 
+    Result = HMM_Divide(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec2
 operator/(hmm_vec2 Left, float Right)
 {
-    hmm_vec2 Result = HMM_Divide(Left, Right);
+    hmm_vec2 Result = {0};
 
+    Result = HMM_Divide(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec3
 operator/(hmm_vec3 Left, float Right)
 {
-    hmm_vec3 Result = HMM_Divide(Left, Right);
+    hmm_vec3 Result = {0};
 
+    Result = HMM_Divide(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec4
 operator/(hmm_vec4 Left, float Right)
 {
-    hmm_vec4 Result = HMM_Divide(Left, Right);
+    hmm_vec4 Result = {0};
 
+    Result = HMM_Divide(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_mat4
 operator/(hmm_mat4 Left, float Right)
 {
-    hmm_mat4 Result = HMM_Divide(Left, Right);
+    hmm_mat4 Result = {0};
 
+    Result = HMM_Divide(Left, Right);
     return (Result);
 }
 
 HINLINE hmm_vec2 &
 operator+=(hmm_vec2 &Left, hmm_vec2 Right)
 {    
-    return(Left = Left + Right);    
+    return (Left = Left + Right);
 }
 
 HINLINE hmm_vec3 &
 operator+=(hmm_vec3 &Left, hmm_vec3 Right)
 {    
-    return(Left = Left + Right);    
+    return (Left = Left + Right);
 }
 
 HINLINE hmm_vec4 &
 operator+=(hmm_vec4 &Left, hmm_vec4 Right)
 {    
-    return(Left = Left + Right);    
+    return (Left = Left + Right);
 }
 
 HINLINE hmm_mat4 &
 operator+=(hmm_mat4 &Left, hmm_mat4 Right)
 {
-    return(Left = Left + Right);
+    return (Left = Left + Right);
 }
 
 HINLINE hmm_vec2 &
 operator-=(hmm_vec2 &Left, hmm_vec2 Right)
 {    
-    return(Left = Left - Right);    
+    return (Left = Left - Right);
 }
 
 HINLINE hmm_vec3 &
 operator-=(hmm_vec3 &Left, hmm_vec3 Right)
 {    
-    return(Left = Left - Right);    
+    return (Left = Left - Right);
 }
 
 HINLINE hmm_vec4 &
 operator-=(hmm_vec4 &Left, hmm_vec4 Right)
 {    
-    return(Left = Left - Right);    
+    return (Left = Left - Right);
 }
 
 HINLINE hmm_mat4 &
 operator-=(hmm_mat4 &Left, hmm_mat4 Right)
 {
-    return(Left = Left - Right);
+    return (Left = Left - Right);
 }
 
 HINLINE hmm_vec2 &
 operator/=(hmm_vec2 &Left, hmm_vec2 Right)
 {    
-    return(Left = Left / Right);    
+    return (Left = Left / Right);
 }
 
 HINLINE hmm_vec3 &
 operator/=(hmm_vec3 &Left, hmm_vec3 Right)
 {    
-    return(Left = Left / Right);    
+    return (Left = Left / Right);
 }
 
 HINLINE hmm_vec4 &
 operator/=(hmm_vec4 &Left, hmm_vec4 Right)
 {    
-    return(Left = Left / Right);    
+    return (Left = Left / Right);
 }
 
 HINLINE hmm_vec2 &
 operator/=(hmm_vec2 &Left, float Right)
 {
-    return(Left = Left / Right);
+    return (Left = Left / Right);
 }
 
 HINLINE hmm_vec3 &
 operator/=(hmm_vec3 &Left, float Right)
 {
-    return(Left = Left / Right);
+    return (Left = Left / Right);
 }
 
 HINLINE hmm_vec4 &
 operator/=(hmm_vec4 &Left, float Right)
 {
-    return(Left = Left / Right);
+    return (Left = Left / Right);
 }
 
 HINLINE hmm_mat4 &
 operator/=(hmm_mat4 &Left, float Right)
 {
-    return(Left = Left / Right);
+    return (Left = Left / Right);
 }
 
 HINLINE hmm_vec2 &
 operator*=(hmm_vec2 &Left, hmm_vec2 Right)
 {    
-    return(Left = Left * Right);    
+    return (Left = Left * Right);
 }
 
 HINLINE hmm_vec3 &
 operator*=(hmm_vec3 &Left, hmm_vec3 Right)
 {    
-    return(Left = Left * Right);    
+    return (Left = Left * Right);
 }
 
 HINLINE hmm_vec4 &
 operator*=(hmm_vec4 &Left, hmm_vec4 Right)
 {    
-    return(Left = Left * Right);    
+    return (Left = Left * Right);
 }
 
 HINLINE hmm_vec2 &
 operator*=(hmm_vec2 &Left, float Right)
 {
-    return(Left = Left * Right);
+    return (Left = Left * Right);
 }
 
 HINLINE hmm_vec3 &
 operator*=(hmm_vec3 &Left, float Right)
 {
-    return(Left = Left * Right);
+    return (Left = Left * Right);
 }
 
 HINLINE hmm_vec4 &
 operator*=(hmm_vec4 &Left, float Right)
 {
-    return(Left = Left * Right);
+    return (Left = Left * Right);
 }
 
 HINLINE hmm_mat4 &
 operator*=(hmm_mat4 &Left, float Right)
 {
-    return(Left = Left * Right);
+    return (Left = Left * Right);
 }
 
 #endif /* HANDMADE_MATH_CPP_MODE */

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -408,14 +408,30 @@ HMMDEF hmm_vec3 operator*(hmm_vec3 Left, hmm_vec3 Right);
 HMMDEF hmm_vec4 operator*(hmm_vec4 Left, hmm_vec4 Right);
 HMMDEF hmm_mat4 operator*(hmm_mat4 Left, hmm_mat4 Right);
 
-HMMDEF hmm_vec3 operator*(hmm_vec3 Left, float Right);
 HMMDEF hmm_vec2 operator*(hmm_vec2 Left, float Right);
+HMMDEF hmm_vec3 operator*(hmm_vec3 Left, float Right);
 
 HMMDEF hmm_vec4 operator*(hmm_mat4 Matrix, hmm_vec4 Vector);
 
 HMMDEF hmm_vec2 operator/(hmm_vec2 Left, hmm_vec2 Right);
 HMMDEF hmm_vec3 operator/(hmm_vec3 Left, hmm_vec3 Right);
 HMMDEF hmm_vec4 operator/(hmm_vec4 Left, hmm_vec4 Right);
+
+HMMDEF hmm_vec2 & operator+=(hmm_vec2 &Left, hmm_vec2 Right);
+HMMDEF hmm_vec3 & operator+=(hmm_vec3 &Left, hmm_vec3 Right);
+HMMDEF hmm_vec4 & operator+=(hmm_vec4 &Left, hmm_vec4 Right);
+
+HMMDEF hmm_vec2 & operator-=(hmm_vec2 &Left, hmm_vec2 Right);
+HMMDEF hmm_vec3 & operator-=(hmm_vec3 &Left, hmm_vec3 Right);
+HMMDEF hmm_vec4 & operator-=(hmm_vec4 &Left, hmm_vec4 Right);
+
+HMMDEF hmm_vec2 & operator*=(hmm_vec2 &Left, hmm_vec2 Right);
+HMMDEF hmm_vec3 & operator*=(hmm_vec3 &Left, hmm_vec3 Right);
+HMMDEF hmm_vec4 & operator*=(hmm_vec4 &Left, hmm_vec4 Right);
+
+HMMDEF hmm_vec2 & operator/=(hmm_vec2 &Left, hmm_vec2 Right);
+HMMDEF hmm_vec3 & operator/=(hmm_vec3 &Left, hmm_vec3 Right);
+HMMDEF hmm_vec4 & operator/=(hmm_vec4 &Left, hmm_vec4 Right);
 
 #endif /* HANDMADE_MATH_CPP */
 
@@ -1219,6 +1235,17 @@ operator*(hmm_vec3 Left, hmm_vec3 Right)
     return (Result);
 }
 
+HINLINE hmm_vec2
+operator*(hmm_vec2 Left, float Right)
+{
+    hmm_vec2 Result;
+
+    Result.X = Right * Left.X;
+    Result.Y = Right * Left.Y;
+
+    return (Result);
+}
+
 HINLINE hmm_vec3
 operator*(hmm_vec3 Left, float Right)
 {
@@ -1227,17 +1254,6 @@ operator*(hmm_vec3 Left, float Right)
     Result.X = Right * Left.X;
     Result.Y = Right * Left.Y;
     Result.Z = Right * Left.Z;
-
-    return (Result);
-}
-
-HINLINE hmm_vec2
-operator*(hmm_vec2 Left, float Right)
-{
-    hmm_vec2 Result;
-
-    Result.X = Right * Left.X;
-    Result.Y = Right * Left.Y;
 
     return (Result);
 }

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -349,18 +349,27 @@ HMMDEF hmm_vec3 HMM_SubtractVec3(hmm_vec3 Left, hmm_vec3 Right);
 HMMDEF hmm_vec4 HMM_SubtractVec4(hmm_vec4 Left, hmm_vec4 Right);
 
 HMMDEF hmm_vec2 HMM_MultiplyVec2(hmm_vec2 Left, hmm_vec2 Right);
+HMMDEF hmm_vec2 HMM_MultiplyVec2f(hmm_vec2 Left, float Right);
 HMMDEF hmm_vec3 HMM_MultiplyVec3(hmm_vec3 Left, hmm_vec3 Right);
+HMMDEF hmm_vec3 HMM_MultiplyVec3f(hmm_vec3 Left, float Right);
 HMMDEF hmm_vec4 HMM_MultiplyVec4(hmm_vec4 Left, hmm_vec4 Right);
+HMMDEF hmm_vec4 HMM_MultiplyVec4f(hmm_vec4 Left, float Right);
 
 HMMDEF hmm_vec2 HMM_DivideVec2(hmm_vec2 Left, hmm_vec2 Right);
+HMMDEF hmm_vec2 HMM_DivideVec2f(hmm_vec2 Left, float Right);
 HMMDEF hmm_vec3 HMM_DivideVec3(hmm_vec3 Left, hmm_vec3 Right);
+HMMDEF hmm_vec3 HMM_DivideVec3f(hmm_vec3 Left, float Right);
 HMMDEF hmm_vec4 HMM_DivideVec4(hmm_vec4 Left, hmm_vec4 Right);
+HMMDEF hmm_vec4 HMM_DivideVec4f(hmm_vec4 Left, float Right);
 
 HMMDEF hmm_mat4 HMM_Mat4(void);
 HMMDEF hmm_mat4 HMM_Mat4d(float Diagonal);
 HMMDEF hmm_mat4 HMM_AddMat4(hmm_mat4 Left, hmm_mat4 Right);
+HMMDEF hmm_mat4 HMM_SubtractMat4(hmm_mat4 Left, hmm_mat4 Right);
 HMMDEF hmm_mat4 HMM_MultiplyMat4(hmm_mat4 Left, hmm_mat4 Right);
+HMMDEF hmm_mat4 HMM_MultiplyMat4f(hmm_mat4 Matrix, float Scalar);
 HMMDEF hmm_vec4 HMM_MultiplyMat4ByVec4(hmm_mat4 Matrix, hmm_vec4 Vector);
+HMMDEF hmm_mat4 HMM_DivideMat4f(hmm_mat4 Matrix, float Scalar);
 
 HMMDEF hmm_mat4 HMM_Orthographic(float Left, float Right, float Bottom, float Top, float Near, float Far);
 HMMDEF hmm_mat4 HMM_Perspective(float FOV, float AspectRatio, float Near, float Far);
@@ -402,6 +411,7 @@ HMMDEF hmm_mat4 operator+(hmm_mat4 Left, hmm_mat4 Right);
 HMMDEF hmm_vec2 operator-(hmm_vec2 Left, hmm_vec2 Right);
 HMMDEF hmm_vec3 operator-(hmm_vec3 Left, hmm_vec3 Right);
 HMMDEF hmm_vec4 operator-(hmm_vec4 Left, hmm_vec4 Right);
+HMMDEF hmm_mat4 operator-(hmm_mat4 Left, hmm_mat4 Right);
 
 HMMDEF hmm_vec2 operator*(hmm_vec2 Left, hmm_vec2 Right);
 HMMDEF hmm_vec3 operator*(hmm_vec3 Left, hmm_vec3 Right);
@@ -410,6 +420,13 @@ HMMDEF hmm_mat4 operator*(hmm_mat4 Left, hmm_mat4 Right);
 
 HMMDEF hmm_vec2 operator*(hmm_vec2 Left, float Right);
 HMMDEF hmm_vec3 operator*(hmm_vec3 Left, float Right);
+HMMDEF hmm_vec4 operator*(hmm_vec4 Left, float Right);
+HMMDEF hmm_mat4 operator*(hmm_mat4 Left, float Right);
+
+HMMDEF hmm_vec2 operator*(float Left, hmm_vec2 Right);
+HMMDEF hmm_vec3 operator*(float Left, hmm_vec3 Right);
+HMMDEF hmm_vec4 operator*(float Left, hmm_vec4 Right);
+HMMDEF hmm_mat4 operator*(float Left, hmm_mat4 Right);
 
 HMMDEF hmm_vec4 operator*(hmm_mat4 Matrix, hmm_vec4 Vector);
 
@@ -417,21 +434,38 @@ HMMDEF hmm_vec2 operator/(hmm_vec2 Left, hmm_vec2 Right);
 HMMDEF hmm_vec3 operator/(hmm_vec3 Left, hmm_vec3 Right);
 HMMDEF hmm_vec4 operator/(hmm_vec4 Left, hmm_vec4 Right);
 
+HMMDEF hmm_vec2 operator/(hmm_vec2 Left, float Right);
+HMMDEF hmm_vec3 operator/(hmm_vec3 Left, float Right);
+HMMDEF hmm_vec4 operator/(hmm_vec4 Left, float Right);
+HMMDEF hmm_mat4 operator/(hmm_mat4 Left, float Right);
+
 HMMDEF hmm_vec2 & operator+=(hmm_vec2 &Left, hmm_vec2 Right);
 HMMDEF hmm_vec3 & operator+=(hmm_vec3 &Left, hmm_vec3 Right);
 HMMDEF hmm_vec4 & operator+=(hmm_vec4 &Left, hmm_vec4 Right);
+HMMDEF hmm_mat4 & operator+=(hmm_mat4 &Left, hmm_mat4 Right);
 
 HMMDEF hmm_vec2 & operator-=(hmm_vec2 &Left, hmm_vec2 Right);
 HMMDEF hmm_vec3 & operator-=(hmm_vec3 &Left, hmm_vec3 Right);
 HMMDEF hmm_vec4 & operator-=(hmm_vec4 &Left, hmm_vec4 Right);
+HMMDEF hmm_mat4 & operator-=(hmm_mat4 &Left, hmm_mat4 Right);
 
 HMMDEF hmm_vec2 & operator*=(hmm_vec2 &Left, hmm_vec2 Right);
 HMMDEF hmm_vec3 & operator*=(hmm_vec3 &Left, hmm_vec3 Right);
 HMMDEF hmm_vec4 & operator*=(hmm_vec4 &Left, hmm_vec4 Right);
 
+HMMDEF hmm_vec2 & operator*=(hmm_vec2 &Left, float Right);
+HMMDEF hmm_vec3 & operator*=(hmm_vec3 &Left, float Right);
+HMMDEF hmm_vec4 & operator*=(hmm_vec4 &Left, float Right);
+HMMDEF hmm_mat4 & operator*=(hmm_mat4 &Left, float Right);
+
 HMMDEF hmm_vec2 & operator/=(hmm_vec2 &Left, hmm_vec2 Right);
 HMMDEF hmm_vec3 & operator/=(hmm_vec3 &Left, hmm_vec3 Right);
 HMMDEF hmm_vec4 & operator/=(hmm_vec4 &Left, hmm_vec4 Right);
+
+HMMDEF hmm_vec2 & operator/=(hmm_vec2 &Left, float Right);
+HMMDEF hmm_vec3 & operator/=(hmm_vec3 &Left, float Right);
+HMMDEF hmm_vec4 & operator/=(hmm_vec4 &Left, float Right);
+HMMDEF hmm_mat4 & operator/=(hmm_mat4 &Left, float Right);
 
 #endif /* HANDMADE_MATH_CPP */
 
@@ -774,6 +808,17 @@ HMM_MultiplyVec2(hmm_vec2 Left, hmm_vec2 Right)
     return (Result);
 }
 
+HINLINE hmm_vec2
+HMM_MultiplyVec2f(hmm_vec2 Left, float Right)
+{
+    hmm_vec2 Result;
+
+    Result.X = Left.X * Right;
+    Result.Y = Left.Y * Right;
+
+    return (Result);
+}
+
 HINLINE hmm_vec3
 HMM_MultiplyVec3(hmm_vec3 Left, hmm_vec3 Right)
 {
@@ -782,6 +827,18 @@ HMM_MultiplyVec3(hmm_vec3 Left, hmm_vec3 Right)
     Result.X = Left.Z * Right.X;
     Result.Y = Left.Y * Right.Y;
     Result.Z = Left.Z * Right.Z;
+
+    return (Result);
+}
+
+HINLINE hmm_vec3
+HMM_MultiplyVec3f(hmm_vec3 Left, float Right)
+{
+    hmm_vec3 Result;
+
+    Result.X = Left.X * Right;
+    Result.Y = Left.Y * Right;
+    Result.Z = Left.Z * Right;
 
     return (Result);
 }
@@ -799,6 +856,19 @@ HMM_MultiplyVec4(hmm_vec4 Left, hmm_vec4 Right)
     return (Result);
 }
 
+HINLINE hmm_vec4
+HMM_MultiplyVec4f(hmm_vec4 Left, float Right)
+{
+    hmm_vec4 Result;
+
+    Result.X = Left.X * Right;
+    Result.Y = Left.Y * Right;
+    Result.Z = Left.Z * Right;
+    Result.W = Left.W * Right;
+
+    return (Result);
+}
+
 HINLINE hmm_vec2
 HMM_DivideVec2(hmm_vec2 Left, hmm_vec2 Right)
 {
@@ -806,6 +876,17 @@ HMM_DivideVec2(hmm_vec2 Left, hmm_vec2 Right)
 
     Result.X = Left.X / Right.X;
     Result.Y = Left.Y / Right.Y;
+
+    return (Result);
+}
+
+HINLINE hmm_vec2
+HMM_DivideVec2f(hmm_vec2 Left, float Right)
+{
+    hmm_vec2 Result;
+
+    Result.X = Left.X / Right;
+    Result.Y = Left.Y / Right;
 
     return (Result);
 }
@@ -822,6 +903,18 @@ HMM_DivideVec3(hmm_vec3 Left, hmm_vec3 Right)
     return (Result);
 }
 
+HINLINE hmm_vec3
+HMM_DivideVec3f(hmm_vec3 Left, float Right)
+{
+    hmm_vec3 Result;
+
+    Result.X = Left.X / Right;
+    Result.Y = Left.Y / Right;
+    Result.Z = Left.Z / Right;
+
+    return (Result);
+}
+
 HINLINE hmm_vec4
 HMM_DivideVec4(hmm_vec4 Left, hmm_vec4 Right)
 {
@@ -831,6 +924,19 @@ HMM_DivideVec4(hmm_vec4 Left, hmm_vec4 Right)
     Result.Y = Left.Y / Right.Y;
     Result.Z = Left.Z / Right.Z;
     Result.W = Left.W / Right.W;
+
+    return (Result);
+}
+
+HINLINE hmm_vec4
+HMM_DivideVec4f(hmm_vec4 Left, float Right)
+{
+    hmm_vec4 Result;
+
+    Result.X = Left.X / Right;
+    Result.Y = Left.Y / Right;
+    Result.Z = Left.Z / Right;
+    Result.W = Left.W / Right;
 
     return (Result);
 }
@@ -884,6 +990,24 @@ HMM_AddMat4(hmm_mat4 Left, hmm_mat4 Right)
     return (Result);
 }
 
+HINLINE hmm_mat4
+HMM_SubtractMat4(hmm_mat4 Left, hmm_mat4 Right)
+{
+    hmm_mat4 Result;
+
+    int Rows;
+    for (Rows = 0; Rows < 4; ++Rows)
+    {
+        int Columns;
+        for (Columns = 0; Columns < 4; ++Columns)
+        {
+            Result.Elements[Rows][Columns] = Left.Elements[Rows][Columns] - Right.Elements[Rows][Columns];
+        }
+    }
+
+    return (Result);
+}
+
 hmm_mat4
 HMM_MultiplyMat4(hmm_mat4 Left, hmm_mat4 Right)
 {
@@ -909,6 +1033,24 @@ HMM_MultiplyMat4(hmm_mat4 Left, hmm_mat4 Right)
     return (Result);
 }
 
+hmm_mat4
+HMM_MultiplyMat4f(hmm_mat4 Matrix, float Scalar)
+{
+    hmm_mat4 Result;
+
+    int Rows;
+    for (Rows = 0; Rows < 4; ++Rows)
+    {
+        int Columns;
+        for (Columns = 0; Columns < 4; ++Columns)
+        {
+            Result.Elements[Rows][Columns] = Matrix.Elements[Rows][Columns] * Scalar;
+        }
+    }
+
+    return (Result);
+}
+
 hmm_vec4
 HMM_MultiplyMat4ByVec4(hmm_mat4 Matrix, hmm_vec4 Vector)
 {
@@ -926,6 +1068,24 @@ HMM_MultiplyMat4ByVec4(hmm_mat4 Matrix, hmm_vec4 Vector)
         Result.Elements[Rows] = Sum;
     }
     
+    return (Result);
+}
+
+hmm_mat4
+HMM_DivideMat4f(hmm_mat4 Matrix, float Scalar)
+{
+    hmm_mat4 Result;
+
+    int Rows;
+    for (Rows = 0; Rows < 4; ++Rows)
+    {
+        int Columns;
+        for (Columns = 0; Columns < 4; ++Columns)
+        {
+            Result.Elements[Rows][Columns] = Matrix.Elements[Rows][Columns] / Scalar;
+        }
+    }
+
     return (Result);
 }
 
@@ -1219,6 +1379,14 @@ operator-(hmm_vec4 Left, hmm_vec4 Right)
     return (Result);
 }
 
+HINLINE hmm_mat4
+operator-(hmm_mat4 Left, hmm_mat4 Right)
+{
+    hmm_mat4 Result = HMM_SubtractMat4(Left, Right);
+
+    return (Result);
+}
+
 HINLINE hmm_vec2
 operator*(hmm_vec2 Left, hmm_vec2 Right)
 {
@@ -1235,13 +1403,18 @@ operator*(hmm_vec3 Left, hmm_vec3 Right)
     return (Result);
 }
 
+HINLINE hmm_vec4
+operator*(hmm_vec4 Left, hmm_vec4 Right)
+{
+    hmm_vec4 Result = Multiply(Left, Right);
+
+    return (Result);
+}
+
 HINLINE hmm_vec2
 operator*(hmm_vec2 Left, float Right)
 {
-    hmm_vec2 Result;
-
-    Result.X = Right * Left.X;
-    Result.Y = Right * Left.Y;
+    hmm_vec2 Result = HMM_MultiplyVec2f(Left, Right);
 
     return (Result);
 }
@@ -1249,19 +1422,55 @@ operator*(hmm_vec2 Left, float Right)
 HINLINE hmm_vec3
 operator*(hmm_vec3 Left, float Right)
 {
-    hmm_vec3 Result;
-
-    Result.X = Right * Left.X;
-    Result.Y = Right * Left.Y;
-    Result.Z = Right * Left.Z;
+    hmm_vec3 Result = HMM_MultiplyVec3f(Left, Right);
 
     return (Result);
 }
 
 HINLINE hmm_vec4
-operator*(hmm_vec4 Left, hmm_vec4 Right)
+operator*(hmm_vec4 Left, float Right)
 {
-    hmm_vec4 Result = Multiply(Left, Right);
+    hmm_vec4 Result = HMM_MultiplyVec4f(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_mat4
+operator*(hmm_mat4 Left, float Right)
+{
+    hmm_mat4 Result = HMM_MultiplyMat4f(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec2
+operator*(float Left, hmm_vec2 Right)
+{
+    hmm_vec2 Result = HMM_MultiplyVec2f(Right, Left);
+
+    return (Result);
+}
+
+HINLINE hmm_vec3
+operator*(float Left, hmm_vec3 Right)
+{
+    hmm_vec3 Result = HMM_MultiplyVec3f(Right, Left);
+
+    return (Result);
+}
+
+HINLINE hmm_vec4
+operator*(float Left, hmm_vec4 Right)
+{
+    hmm_vec4 Result = HMM_MultiplyVec4f(Right, Left);
+
+    return (Result);
+}
+
+HINLINE hmm_mat4
+operator*(float Left, hmm_mat4 Right)
+{
+    hmm_mat4 Result = HMM_MultiplyMat4f(Right, Left);
 
     return (Result);
 }
@@ -1306,6 +1515,38 @@ operator/(hmm_vec4 Left, hmm_vec4 Right)
     return (Result);
 }
 
+HINLINE hmm_vec2
+operator/(hmm_vec2 Left, float Right)
+{
+    hmm_vec2 Result = HMM_DivideVec2f(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec3
+operator/(hmm_vec3 Left, float Right)
+{
+    hmm_vec3 Result = HMM_DivideVec3f(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec4
+operator/(hmm_vec4 Left, float Right)
+{
+    hmm_vec4 Result = HMM_DivideVec4f(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_mat4
+operator/(hmm_mat4 Left, float Right)
+{
+    hmm_mat4 Result = HMM_DivideMat4f(Left, Right);
+
+    return (Result);
+}
+
 HINLINE hmm_vec2 &
 operator+=(hmm_vec2 &Left, hmm_vec2 Right)
 {    
@@ -1324,12 +1565,17 @@ operator+=(hmm_vec4 &Left, hmm_vec4 Right)
     return(Left = Left + Right);    
 }
 
+HINLINE hmm_mat4 &
+operator+=(hmm_mat4 &Left, hmm_mat4 Right)
+{
+    return(Left = Left + Right);
+}
+
 HINLINE hmm_vec2 &
 operator-=(hmm_vec2 &Left, hmm_vec2 Right)
 {    
     return(Left = Left - Right);    
 }
-
 
 HINLINE hmm_vec3 &
 operator-=(hmm_vec3 &Left, hmm_vec3 Right)
@@ -1337,11 +1583,16 @@ operator-=(hmm_vec3 &Left, hmm_vec3 Right)
     return(Left = Left - Right);    
 }
 
-
 HINLINE hmm_vec4 &
 operator-=(hmm_vec4 &Left, hmm_vec4 Right)
 {    
     return(Left = Left - Right);    
+}
+
+HINLINE hmm_mat4 &
+operator-=(hmm_mat4 &Left, hmm_mat4 Right)
+{
+    return(Left = Left - Right);
 }
 
 HINLINE hmm_vec2 &
@@ -1363,6 +1614,30 @@ operator/=(hmm_vec4 &Left, hmm_vec4 Right)
 }
 
 HINLINE hmm_vec2 &
+operator/=(hmm_vec2 &Left, float Right)
+{
+    return(Left = Left / Right);
+}
+
+HINLINE hmm_vec3 &
+operator/=(hmm_vec3 &Left, float Right)
+{
+    return(Left = Left / Right);
+}
+
+HINLINE hmm_vec4 &
+operator/=(hmm_vec4 &Left, float Right)
+{
+    return(Left = Left / Right);
+}
+
+HINLINE hmm_mat4 &
+operator/=(hmm_mat4 &Left, float Right)
+{
+    return(Left = Left / Right);
+}
+
+HINLINE hmm_vec2 &
 operator*=(hmm_vec2 &Left, hmm_vec2 Right)
 {    
     return(Left = Left * Right);    
@@ -1374,11 +1649,34 @@ operator*=(hmm_vec3 &Left, hmm_vec3 Right)
     return(Left = Left * Right);    
 }
 
-
 HINLINE hmm_vec4 &
 operator*=(hmm_vec4 &Left, hmm_vec4 Right)
 {    
     return(Left = Left * Right);    
+}
+
+HINLINE hmm_vec2 &
+operator*=(hmm_vec2 &Left, float Right)
+{
+    return(Left = Left * Right);
+}
+
+HINLINE hmm_vec3 &
+operator*=(hmm_vec3 &Left, float Right)
+{
+    return(Left = Left * Right);
+}
+
+HINLINE hmm_vec4 &
+operator*=(hmm_vec4 &Left, float Right)
+{
+    return(Left = Left * Right);
+}
+
+HINLINE hmm_mat4 &
+operator*=(hmm_mat4 &Left, float Right)
+{
+    return(Left = Left * Right);
 }
 
 #endif /* HANDMADE_MATH_CPP_MODE */

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -385,23 +385,33 @@ HMMDEF hmm_mat4 HMM_LookAt(hmm_vec3 Eye, hmm_vec3 Center, hmm_vec3 Up);
 
 #ifdef HANDMADE_MATH_CPP_MODE
 
-HMMDEF hmm_vec2 HMM_Add(int X, int Y);
-HMMDEF hmm_vec3 HMM_Add(int X, int Y, int Z);
-HMMDEF hmm_vec4 HMM_Add(int X, int Y, int Z, int W);
+HMMDEF hmm_vec2 HMM_Add(hmm_vec2 Left, hmm_vec2 Right);
+HMMDEF hmm_vec3 HMM_Add(hmm_vec3 Left, hmm_vec3 Right);
+HMMDEF hmm_vec4 HMM_Add(hmm_vec4 Left, hmm_vec4 Right);
+HMMDEF hmm_mat4 HMM_Add(hmm_mat4 Left, hmm_mat4 Right);
 
-HMMDEF hmm_vec2 HMM_Subtract(int X, int Y);
-HMMDEF hmm_vec3 HMM_Subtract(int X, int Y, int Z);
-HMMDEF hmm_vec4 HMM_Subtract(int X, int Y, int Z, int W);
+HMMDEF hmm_vec2 HMM_Subtract(hmm_vec2 Left, hmm_vec2 Right);
+HMMDEF hmm_vec3 HMM_Subtract(hmm_vec3 Left, hmm_vec3 Right);
+HMMDEF hmm_vec4 HMM_Subtract(hmm_vec4 Left, hmm_vec4 Right);
+HMMDEF hmm_mat4 HMM_Subtract(hmm_mat4 Left, hmm_mat4 Right);
 
-HMMDEF hmm_vec2 HMM_Multiply(int X, int Y);
-HMMDEF hmm_vec3 HMM_Multiply(int X, int Y, int Z);
-HMMDEF hmm_vec4 HMM_Multiply(int X, int Y, int Z, int W);
+HMMDEF hmm_vec2 HMM_Multiply(hmm_vec2 Left, hmm_vec2 Right);
+HMMDEF hmm_vec2 HMM_Multiply(hmm_vec2 Left, float Right);
+HMMDEF hmm_vec3 HMM_Multiply(hmm_vec3 Left, hmm_vec3 Right);
+HMMDEF hmm_vec3 HMM_Multiply(hmm_vec3 Left, float Right);
+HMMDEF hmm_vec4 HMM_Multiply(hmm_vec4 Left, hmm_vec4 Right);
+HMMDEF hmm_vec4 HMM_Multiply(hmm_vec4 Left, float Right);
 HMMDEF hmm_mat4 HMM_Multiply(hmm_mat4 Left, hmm_mat4 Right);
+HMMDEF hmm_mat4 HMM_Multiply(hmm_mat4 Left, float Right);
 HMMDEF hmm_vec4 HMM_Multiply(hmm_mat4 Matrix, hmm_vec4 Vector);
 
-HMMDEF hmm_vec2 HMM_Divide(int X, int Y);
-HMMDEF hmm_vec3 HMM_Divide(int X, int Y, int Z);
-HMMDEF hmm_vec4 HMM_Divide(int X, int Y, int Z, int W);
+HMMDEF hmm_vec2 HMM_Divide(hmm_vec2 Left, hmm_vec2 Right);
+HMMDEF hmm_vec2 HMM_Divide(hmm_vec2 Left, float Right);
+HMMDEF hmm_vec3 HMM_Divide(hmm_vec3 Left, hmm_vec3 Right);
+HMMDEF hmm_vec3 HMM_Divide(hmm_vec3 Left, float Right);
+HMMDEF hmm_vec4 HMM_Divide(hmm_vec4 Left, hmm_vec4 Right);
+HMMDEF hmm_vec4 HMM_Divide(hmm_vec4 Left, float Right);
+HMMDEF hmm_mat4 HMM_Divide(hmm_mat4 Left, float Right);
 
 HMMDEF hmm_vec2 operator+(hmm_vec2 Left, hmm_vec2 Right);
 HMMDEF hmm_vec3 operator+(hmm_vec3 Left, hmm_vec3 Right);
@@ -1208,7 +1218,7 @@ HMM_Scale(hmm_vec3 Scale)
 #ifdef HANDMADE_MATH_CPP_MODE
 
 HINLINE hmm_vec2
-Add(hmm_vec2 Left, hmm_vec2 Right)
+HMM_Add(hmm_vec2 Left, hmm_vec2 Right)
 {
     hmm_vec2 Result = HMM_AddVec2(Left, Right);
 
@@ -1216,7 +1226,7 @@ Add(hmm_vec2 Left, hmm_vec2 Right)
 }
 
 HINLINE hmm_vec3
-Add(hmm_vec3 Left, hmm_vec3 Right)
+HMM_Add(hmm_vec3 Left, hmm_vec3 Right)
 {
     hmm_vec3 Result = HMM_AddVec3(Left, Right);
 
@@ -1224,7 +1234,7 @@ Add(hmm_vec3 Left, hmm_vec3 Right)
 }
 
 HMMDEF HINLINE hmm_vec4
-Add(hmm_vec4 Left, hmm_vec4 Right)
+HMM_Add(hmm_vec4 Left, hmm_vec4 Right)
 {
     hmm_vec4 Result = HMM_AddVec4(Left, Right);
 
@@ -1232,7 +1242,7 @@ Add(hmm_vec4 Left, hmm_vec4 Right)
 }
 
 HINLINE hmm_mat4
-Add(hmm_mat4 Left, hmm_mat4 Right)
+HMM_Add(hmm_mat4 Left, hmm_mat4 Right)
 {
     hmm_mat4 Result = HMM_AddMat4(Left, Right);
 
@@ -1240,7 +1250,7 @@ Add(hmm_mat4 Left, hmm_mat4 Right)
 }
 
 HINLINE hmm_vec2
-Subtract(hmm_vec2 Left, hmm_vec2 Right)
+HMM_Subtract(hmm_vec2 Left, hmm_vec2 Right)
 {
     hmm_vec2 Result = HMM_SubtractVec2(Left, Right);
 
@@ -1248,7 +1258,7 @@ Subtract(hmm_vec2 Left, hmm_vec2 Right)
 }
 
 HINLINE hmm_vec3
-Subtract(hmm_vec3 Left, hmm_vec3 Right)
+HMM_Subtract(hmm_vec3 Left, hmm_vec3 Right)
 {
     hmm_vec3 Result = HMM_SubtractVec3(Left, Right);
 
@@ -1256,135 +1266,15 @@ Subtract(hmm_vec3 Left, hmm_vec3 Right)
 }
 
 HINLINE hmm_vec4
-Subtract(hmm_vec4 Left, hmm_vec4 Right)
+HMM_Subtract(hmm_vec4 Left, hmm_vec4 Right)
 {
     hmm_vec4 Result = HMM_SubtractVec4(Left, Right);
 
     return (Result);
 }
 
-HINLINE hmm_vec2
-Multiply(hmm_vec2 Left, hmm_vec2 Right)
-{
-    hmm_vec2 Result = HMM_MultiplyVec2(Left, Right);
-
-    return (Result);
-}
-
-HINLINE hmm_vec3
-Multiply(hmm_vec3 Left, hmm_vec3 Right)
-{
-    hmm_vec3 Result = HMM_MultiplyVec3(Left, Right);
-
-    return (Result);
-}
-
-HINLINE hmm_vec4
-Multiply(hmm_vec4 Left, hmm_vec4 Right)
-{
-    hmm_vec4 Result = HMM_MultiplyVec4(Left, Right);
-
-    return (Result);
-}
-
 HINLINE hmm_mat4
-Multiply(hmm_mat4 Left, hmm_mat4 Right)
-{
-    hmm_mat4 Result = HMM_MultiplyMat4(Left, Right);
-
-    return (Result);
-}
-
-HINLINE hmm_vec4
-Multiply(hmm_mat4 Matrix, hmm_vec4 Vector)
-{
-    hmm_vec4 Result = HMM_MultiplyMat4ByVec4(Matrix, Vector);
-    
-    return (Result);
-}
-
-HINLINE hmm_vec2
-Divide(hmm_vec2 Left, hmm_vec2 Right)
-{
-    hmm_vec2 Result = HMM_DivideVec2(Left, Right);
-
-    return (Result);
-}
-
-HINLINE hmm_vec3
-Divide(hmm_vec3 Left, hmm_vec3 Right)
-{
-    hmm_vec3 Result = HMM_DivideVec3(Left, Right);
-
-    return (Result);
-}
-
-HINLINE hmm_vec4
-Divide(hmm_vec4 Left, hmm_vec4 Right)
-{
-    hmm_vec4 Result = HMM_DivideVec4(Left, Right);
-
-    return (Result);
-}
-
-HINLINE hmm_vec2
-operator+(hmm_vec2 Left, hmm_vec2 Right)
-{
-    hmm_vec2 Result = Add(Left, Right);
-
-    return (Result);
-}
-
-HINLINE hmm_vec3
-operator+(hmm_vec3 Left, hmm_vec3 Right)
-{
-    hmm_vec3 Result = Add(Left, Right);
-
-    return (Result);
-}
-
-HINLINE hmm_vec4
-operator+(hmm_vec4 Left, hmm_vec4 Right)
-{
-    hmm_vec4 Result = Add(Left, Right);
-
-    return (Result);
-}
-
-HINLINE hmm_mat4
-operator+(hmm_mat4 Left, hmm_mat4 Right)
-{
-    hmm_mat4 Result = Add(Left, Right);
-
-    return (Result);
-}
-
-HINLINE hmm_vec2
-operator-(hmm_vec2 Left, hmm_vec2 Right)
-{
-    hmm_vec2 Result = Subtract(Left, Right);
-
-    return (Result);
-}
-
-HINLINE hmm_vec3
-operator-(hmm_vec3 Left, hmm_vec3 Right)
-{
-    hmm_vec3 Result = Subtract(Left, Right);
-
-    return (Result);
-}
-
-HINLINE hmm_vec4
-operator-(hmm_vec4 Left, hmm_vec4 Right)
-{
-    hmm_vec4 Result = Subtract(Left, Right);
-
-    return (Result);
-}
-
-HINLINE hmm_mat4
-operator-(hmm_mat4 Left, hmm_mat4 Right)
+HMM_Subtract(hmm_mat4 Left, hmm_mat4 Right)
 {
     hmm_mat4 Result = HMM_SubtractMat4(Left, Right);
 
@@ -1392,31 +1282,15 @@ operator-(hmm_mat4 Left, hmm_mat4 Right)
 }
 
 HINLINE hmm_vec2
-operator*(hmm_vec2 Left, hmm_vec2 Right)
+HMM_Multiply(hmm_vec2 Left, hmm_vec2 Right)
 {
-    hmm_vec2 Result = Multiply(Left, Right);
-
-    return (Result);
-}
-
-HINLINE hmm_vec3
-operator*(hmm_vec3 Left, hmm_vec3 Right)
-{
-    hmm_vec3 Result = Multiply(Left, Right);
-
-    return (Result);
-}
-
-HINLINE hmm_vec4
-operator*(hmm_vec4 Left, hmm_vec4 Right)
-{
-    hmm_vec4 Result = Multiply(Left, Right);
+    hmm_vec2 Result = HMM_MultiplyVec2(Left, Right);
 
     return (Result);
 }
 
 HINLINE hmm_vec2
-operator*(hmm_vec2 Left, float Right)
+HMM_Multiply(hmm_vec2 Left, float Right)
 {
     hmm_vec2 Result = HMM_MultiplyVec2f(Left, Right);
 
@@ -1424,7 +1298,15 @@ operator*(hmm_vec2 Left, float Right)
 }
 
 HINLINE hmm_vec3
-operator*(hmm_vec3 Left, float Right)
+HMM_Multiply(hmm_vec3 Left, hmm_vec3 Right)
+{
+    hmm_vec3 Result = HMM_MultiplyVec3(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec3
+HMM_Multiply(hmm_vec3 Left, float Right)
 {
     hmm_vec3 Result = HMM_MultiplyVec3f(Left, Right);
 
@@ -1432,7 +1314,15 @@ operator*(hmm_vec3 Left, float Right)
 }
 
 HINLINE hmm_vec4
-operator*(hmm_vec4 Left, float Right)
+HMM_Multiply(hmm_vec4 Left, hmm_vec4 Right)
+{
+    hmm_vec4 Result = HMM_MultiplyVec4(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec4
+HMM_Multiply(hmm_vec4 Left, float Right)
 {
     hmm_vec4 Result = HMM_MultiplyVec4f(Left, Right);
 
@@ -1440,87 +1330,39 @@ operator*(hmm_vec4 Left, float Right)
 }
 
 HINLINE hmm_mat4
-operator*(hmm_mat4 Left, float Right)
+HMM_Multiply(hmm_mat4 Left, hmm_mat4 Right)
+{
+    hmm_mat4 Result = HMM_MultiplyMat4(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_mat4
+HMM_Multiply(hmm_mat4 Left, float Right)
 {
     hmm_mat4 Result = HMM_MultiplyMat4f(Left, Right);
 
     return (Result);
 }
 
-HINLINE hmm_vec2
-operator*(float Left, hmm_vec2 Right)
-{
-    hmm_vec2 Result = HMM_MultiplyVec2f(Right, Left);
-
-    return (Result);
-}
-
-HINLINE hmm_vec3
-operator*(float Left, hmm_vec3 Right)
-{
-    hmm_vec3 Result = HMM_MultiplyVec3f(Right, Left);
-
-    return (Result);
-}
-
 HINLINE hmm_vec4
-operator*(float Left, hmm_vec4 Right)
+HMM_Multiply(hmm_mat4 Matrix, hmm_vec4 Vector)
 {
-    hmm_vec4 Result = HMM_MultiplyVec4f(Right, Left);
-
-    return (Result);
-}
-
-HINLINE hmm_mat4
-operator*(float Left, hmm_mat4 Right)
-{
-    hmm_mat4 Result = HMM_MultiplyMat4f(Right, Left);
-
-    return (Result);
-}
-
-HINLINE hmm_mat4
-operator*(hmm_mat4 Left, hmm_mat4 Right)
-{
-    hmm_mat4 Result = Multiply(Left, Right);
-
-    return (Result);
-}
-
-HINLINE hmm_vec4
-operator*(hmm_mat4 Matrix, hmm_vec4 Vector)
-{
-    hmm_vec4 Result = Multiply(Matrix, Vector);
+    hmm_vec4 Result = HMM_MultiplyMat4ByVec4(Matrix, Vector);
     
     return (Result);
 }
 
 HINLINE hmm_vec2
-operator/(hmm_vec2 Left, hmm_vec2 Right)
+HMM_Divide(hmm_vec2 Left, hmm_vec2 Right)
 {
-    hmm_vec2 Result = Divide(Left, Right);
-
-    return (Result);
-}
-
-HINLINE hmm_vec3
-operator/(hmm_vec3 Left, hmm_vec3 Right)
-{
-    hmm_vec3 Result = Divide(Left, Right);
-
-    return (Result);
-}
-
-HINLINE hmm_vec4
-operator/(hmm_vec4 Left, hmm_vec4 Right)
-{
-    hmm_vec4 Result = Divide(Left, Right);
+    hmm_vec2 Result = HMM_DivideVec2(Left, Right);
 
     return (Result);
 }
 
 HINLINE hmm_vec2
-operator/(hmm_vec2 Left, float Right)
+HMM_Divide(hmm_vec2 Left, float Right)
 {
     hmm_vec2 Result = HMM_DivideVec2f(Left, Right);
 
@@ -1528,7 +1370,15 @@ operator/(hmm_vec2 Left, float Right)
 }
 
 HINLINE hmm_vec3
-operator/(hmm_vec3 Left, float Right)
+HMM_Divide(hmm_vec3 Left, hmm_vec3 Right)
+{
+    hmm_vec3 Result = HMM_DivideVec3(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec3
+HMM_Divide(hmm_vec3 Left, float Right)
 {
     hmm_vec3 Result = HMM_DivideVec3f(Left, Right);
 
@@ -1536,7 +1386,15 @@ operator/(hmm_vec3 Left, float Right)
 }
 
 HINLINE hmm_vec4
-operator/(hmm_vec4 Left, float Right)
+HMM_Divide(hmm_vec4 Left, hmm_vec4 Right)
+{
+    hmm_vec4 Result = HMM_DivideVec4(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec4
+HMM_Divide(hmm_vec4 Left, float Right)
 {
     hmm_vec4 Result = HMM_DivideVec4f(Left, Right);
 
@@ -1544,9 +1402,233 @@ operator/(hmm_vec4 Left, float Right)
 }
 
 HINLINE hmm_mat4
-operator/(hmm_mat4 Left, float Right)
+HMM_Divide(hmm_mat4 Left, float Right)
 {
     hmm_mat4 Result = HMM_DivideMat4f(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec2
+operator+(hmm_vec2 Left, hmm_vec2 Right)
+{
+    hmm_vec2 Result = HMM_Add(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec3
+operator+(hmm_vec3 Left, hmm_vec3 Right)
+{
+    hmm_vec3 Result = HMM_Add(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec4
+operator+(hmm_vec4 Left, hmm_vec4 Right)
+{
+    hmm_vec4 Result = HMM_Add(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_mat4
+operator+(hmm_mat4 Left, hmm_mat4 Right)
+{
+    hmm_mat4 Result = HMM_Add(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec2
+operator-(hmm_vec2 Left, hmm_vec2 Right)
+{
+    hmm_vec2 Result = HMM_Subtract(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec3
+operator-(hmm_vec3 Left, hmm_vec3 Right)
+{
+    hmm_vec3 Result = HMM_Subtract(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec4
+operator-(hmm_vec4 Left, hmm_vec4 Right)
+{
+    hmm_vec4 Result = HMM_Subtract(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_mat4
+operator-(hmm_mat4 Left, hmm_mat4 Right)
+{
+    hmm_mat4 Result = HMM_Subtract(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec2
+operator*(hmm_vec2 Left, hmm_vec2 Right)
+{
+    hmm_vec2 Result = HMM_Multiply(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec3
+operator*(hmm_vec3 Left, hmm_vec3 Right)
+{
+    hmm_vec3 Result = HMM_Multiply(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec4
+operator*(hmm_vec4 Left, hmm_vec4 Right)
+{
+    hmm_vec4 Result = HMM_Multiply(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec2
+operator*(hmm_vec2 Left, float Right)
+{
+    hmm_vec2 Result = HMM_Multiply(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec3
+operator*(hmm_vec3 Left, float Right)
+{
+    hmm_vec3 Result = HMM_Multiply(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec4
+operator*(hmm_vec4 Left, float Right)
+{
+    hmm_vec4 Result = HMM_Multiply(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_mat4
+operator*(hmm_mat4 Left, float Right)
+{
+    hmm_mat4 Result = HMM_Multiply(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec2
+operator*(float Left, hmm_vec2 Right)
+{
+    hmm_vec2 Result = HMM_Multiply(Right, Left);
+
+    return (Result);
+}
+
+HINLINE hmm_vec3
+operator*(float Left, hmm_vec3 Right)
+{
+    hmm_vec3 Result = HMM_Multiply(Right, Left);
+
+    return (Result);
+}
+
+HINLINE hmm_vec4
+operator*(float Left, hmm_vec4 Right)
+{
+    hmm_vec4 Result = HMM_Multiply(Right, Left);
+
+    return (Result);
+}
+
+HINLINE hmm_mat4
+operator*(float Left, hmm_mat4 Right)
+{
+    hmm_mat4 Result = HMM_Multiply(Right, Left);
+
+    return (Result);
+}
+
+HINLINE hmm_mat4
+operator*(hmm_mat4 Left, hmm_mat4 Right)
+{
+    hmm_mat4 Result = HMM_Multiply(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec4
+operator*(hmm_mat4 Matrix, hmm_vec4 Vector)
+{
+    hmm_vec4 Result = HMM_Multiply(Matrix, Vector);
+    
+    return (Result);
+}
+
+HINLINE hmm_vec2
+operator/(hmm_vec2 Left, hmm_vec2 Right)
+{
+    hmm_vec2 Result = HMM_Divide(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec3
+operator/(hmm_vec3 Left, hmm_vec3 Right)
+{
+    hmm_vec3 Result = HMM_Divide(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec4
+operator/(hmm_vec4 Left, hmm_vec4 Right)
+{
+    hmm_vec4 Result = HMM_Divide(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec2
+operator/(hmm_vec2 Left, float Right)
+{
+    hmm_vec2 Result = HMM_Divide(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec3
+operator/(hmm_vec3 Left, float Right)
+{
+    hmm_vec3 Result = HMM_Divide(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_vec4
+operator/(hmm_vec4 Left, float Right)
+{
+    hmm_vec4 Result = HMM_Divide(Left, Right);
+
+    return (Result);
+}
+
+HINLINE hmm_mat4
+operator/(hmm_mat4 Left, float Right)
+{
+    hmm_mat4 Result = HMM_Divide(Left, Right);
 
     return (Result);
 }

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Single-file public domain game math library for C/C++
 
 Version         | Changes | 
 ----------------|----------------|
+**0.5**     | Added scalar operations on vectors and matrices, added += and -= for hmm_mat4, reconciled headers and implementations, tidied up in general |
 **0.4**     | Added SSE Optimized HMM_SqrtF, HMM_RSqrtF, Removed use of CRT              | 
 **0.3**     | Added +=,-=, *=, /= for hmm_vec2, hmm_vec3, hmm_vec4              | 
 **0.2b**     | Disabled warning C4201 on MSVC, Added 64bit percision on HMM_PI              | 
@@ -21,6 +22,6 @@ _ID: In Development_
 
 This library is in the public domain. You can do whatever you want with them.
 
-**Where can i contact you to ask quesitons ?**
+**Where can I contact you to ask questions?**
 
 You can email me at: Zak@Handmade.Network


### PR DESCRIPTION
This one's big! Here's a breakdown of what's in this PR:

- Added missing headers for existing operator overloads
- Added scalar multiplication of vectors and matrices
  - This was present for only vec2's and vec3's using operator
overloading. In addition, there was only operator overloading for
[structure] * float, not float * [structure].
  - Additionally, the two operators that were already defined were
updated to use the new C-style functions that were defined.
- Added scalar division of vectors and matrices
- Added matrix subtraction
- Added += operator for matrices