### PR TITLE
Accelerate HMM_Power() with the squaring technique

### DIFF
--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -598,27 +598,21 @@ HMM_Length(hmm_vec3 A)
 HINLINE float
 HMM_Power(float Base, int Exponent)
 {
-    float Result = 1;
-
-    if(Exponent > 0)
+    float Result = 1.0f;
+    float Mul = Exponent < 0 ? 1.f / Base : Base;
+    unsigned int X = Exponent < 0 ? -Exponent : Exponent;
+    while (X)
     {
-        int i;
-        for(i = 0; i < Exponent; ++i)
+        if (X & 1)
         {
-            Result *= Base;
+            Result *= Mul;
         }
+        Mul *= Mul;
+        X >>= 1;
     }
-    else
-    {
-        int i;
-        for(i = 0; i > Exponent; --i)
-        {
-            Result /= Base;
-        }
-    }
-
     return (Result);
 }
+
 
 HINLINE float
 HMM_Lerp(float A, float Time, float B)


### PR DESCRIPTION
Thanks to @mmozeiko for the algorithm

As I understand it, there's scope to further accelerate HMM_Power() with the addition-chain technique, but it could be worthwhile getting this version using the squaring technique into the library now because it brings a massive speed boost over the previous algorithm.