### PR TITLE
Add Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: cpp
+compiler:
+  - clang
+  - gcc
+install:
+  - cd test
+  - make
+script: ./hmm_test


### PR DESCRIPTION
I tested this on my fork and it works great!

Once this is merged, you will have to go to http://travis-ci.org/ and enable Travis builds for the main Handmade Math repo. You shouldn't have to do anything more than just enabling it for the repo.