### PR TITLE
Restrict struct warning suppression to clang only

### DIFF
--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -153,7 +153,6 @@
           (*) Added HMM_NormalizeVec4
      1.0
           (*) Lots of testing!
-
      1.1
           (*) Quaternion support
           (*) Added type hmm_quaternion
@@ -170,6 +169,8 @@
           (*) Added HMM_Slerp
           (*) Added HMM_QuaternionToMat4
           (*) Added HMM_QuaternionFromAxisAngle
+     1.1.1
+          (*) Resolved compiler warnings on gcc and g++
           
   LICENSE
   

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -206,7 +206,8 @@
 #pragma warning(disable:4201)
 #endif
 
-#ifdef __GNUC__
+#ifdef __clang__
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wgnu-anonymous-struct"
 #endif
 
@@ -2644,3 +2645,7 @@ operator*=(hmm_quaternion &Left, float Right)
 #endif /* HANDMADE_MATH_CPP_MODE */
 
 #endif /* HANDMADE_MATH_IMPLEMENTATION */
+
+#ifdef __clang__
+#pragma GCC diagnostic pop
+#endif

--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -659,6 +659,10 @@ HMMDEF hmm_quaternion &operator/=(hmm_quaternion &Left, float Right);
 
 #endif /* HANDMADE_MATH_CPP */
 
+#ifdef __clang__
+#pragma GCC diagnostic pop
+#endif
+
 #endif /* HANDMADE_MATH_H */
 
 #ifdef HANDMADE_MATH_IMPLEMENTATION
@@ -2646,7 +2650,3 @@ operator*=(hmm_quaternion &Left, float Right)
 #endif /* HANDMADE_MATH_CPP_MODE */
 
 #endif /* HANDMADE_MATH_IMPLEMENTATION */
-
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif


### PR DESCRIPTION
Fixes the warnings recently reported by @DanielGibson in #45. It seems that `-Wgnu-anonymous-struct` is a flag for clang only, since gcc and g++ apparently support anonymous structs out of the box.

As a side note, our Travis is set up to build in both clang and g++, and the clang build showed no warnings even before #45 was merged. (And this is with `-Wall` enabled.)