### PR TITLE
Make it usable on non-SSE platforms

### DIFF
--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -200,7 +200,27 @@
    Insofaras (@insofaras)
 */
 
-#ifndef HANDMADE_NO_SSE
+
+// let's figure out if SSE is really available (unless disabled anyway)
+// (it isn't on non-x86/x86_64 platforms or even x86 without explicit SSE support)
+// => only use "#ifdef HANDMADE_MATH__USE_SSE" to check for SSE support below this block!
+#ifndef HANDMADE_MATH_NO_SSE
+
+# ifdef _MSC_VER
+   // MSVC supports SSE in amd64 mode or _M_IX86_FP >= 1 (2 means SSE2)
+#  if defined(_M_AMD64) || ( defined(_M_IX86_FP) && _M_IX86_FP >= 1 )
+#   define HANDMADE_MATH__USE_SSE 1
+#  endif
+# else // not MSVC, probably GCC, clang, icc or something that doesn't support SSE anyway
+#  ifdef __SSE__ // they #define __SSE__ if it's supported
+#   define HANDMADE_MATH__USE_SSE 1
+#  endif //  __SSE__
+# endif // not _MSC_VER
+
+#endif // #ifndef HANDMADE_MATH_NO_SSE
+
+
+#ifdef HANDMADE_MATH__USE_SSE
 #include <xmmintrin.h>
 #endif
 
@@ -757,12 +777,12 @@ HMM_SquareRootF(float Value)
 {
     float Result = 0.0f;
 
-#ifdef HANDMADE_MATH_NO_SSE
-    Result = sqrtf(Value);
-#else        
+#ifdef HANDMADE_MATH__USE_SSE
     __m128 In = _mm_set_ss(Value);
     __m128 Out = _mm_sqrt_ss(In);
     Result = _mm_cvtss_f32(Out);
+#else
+    Result = sqrtf(Value);
 #endif 
 
     return(Result);
@@ -773,12 +793,12 @@ HMM_RSquareRootF(float Value)
 {
     float Result = 0.0f;
 
-#ifdef HANDMADE_MATH_NO_SSE
-    Result = 1.0f/HMM_SqrtF(Value);    
-#else        
+#ifdef HANDMADE_MATH__USE_SSE
     __m128 In = _mm_set_ss(Value);
     __m128 Out = _mm_rsqrt_ss(In);
     Result = _mm_cvtss_f32(Out);
+#else
+    Result = 1.0f/HMM_SquareRootF(Value);
 #endif
 
     return(Result);


### PR DESCRIPTION
For Yamagi Quake2 we had a [bugreport that it doesn't build on ARM due to HMM](https://github.com/yquake2/yquake2/issues/204), so I looked into the issue and (hopefully!) fixed it

* at one place HANDMADE_NO_SSE instead of HANDMADE_MATH_NO_SSE was used
* introduce HANDMADE_MATH__USE_SSE for the SSE #ifdefs throughout code
  - use #ifdef HANDMADE_MATH_NO_SSE at only one place
* only use SSE (#define HANDMADE_MATH__USE_SSE) if the targetplatform
  actually supports it
  => users don't have to #define HANDMADE_MATH_NO_SSE on ARM etc
* at one place HMM_SqrtF instead of HMM_SquareRootF was used