### PR TITLE
Handle zero-vector normalization.

### DIFF
--- a/HandmadeMath.h
+++ b/HandmadeMath.h
@@ -923,8 +923,12 @@ HMM_NormalizeVec2(hmm_vec2 A)
 
     float VectorLength = HMM_LengthVec2(A);
     
-    Result.X = A.X * (1.0f / VectorLength);
-    Result.Y = A.Y * (1.0f / VectorLength);
+    /* NOTE(kiljacken): We need a zero check to not divide-by-zero */
+    if (VectorLength != 0.0f)
+    {
+        Result.X = A.X * (1.0f / VectorLength);
+        Result.Y = A.Y * (1.0f / VectorLength);
+    }
     
     return (Result);
 }
@@ -936,9 +940,13 @@ HMM_NormalizeVec3(hmm_vec3 A)
 
     float VectorLength = HMM_LengthVec3(A);
     
-    Result.X = A.X * (1.0f / VectorLength);
-    Result.Y = A.Y * (1.0f / VectorLength);
-    Result.Z = A.Z * (1.0f / VectorLength);
+    /* NOTE(kiljacken): We need a zero check to not divide-by-zero */
+    if (VectorLength != 0.0f)
+    {
+        Result.X = A.X * (1.0f / VectorLength);
+        Result.Y = A.Y * (1.0f / VectorLength);
+        Result.Z = A.Z * (1.0f / VectorLength);
+    }
     
     return (Result);
 }
@@ -950,10 +958,14 @@ HMM_NormalizeVec4(hmm_vec4 A)
 
     float VectorLength = HMM_LengthVec4(A);
     
-    Result.X = A.X * (1.0f / VectorLength);
-    Result.Y = A.Y * (1.0f / VectorLength);
-    Result.Z = A.Z * (1.0f / VectorLength);
-    Result.W = A.W * (1.0f / VectorLength);
+    /* NOTE(kiljacken): We need a zero check to not divide-by-zero */
+    if (VectorLength != 0.0f)
+    {
+        Result.X = A.X * (1.0f / VectorLength);
+        Result.Y = A.Y * (1.0f / VectorLength);
+        Result.Z = A.Z * (1.0f / VectorLength);
+        Result.W = A.W * (1.0f / VectorLength);
+    }
     
     return (Result);
 }

--- a/test/hmm_test.c
+++ b/test/hmm_test.c
@@ -310,6 +310,54 @@ int run_tests()
         }
         TEST_END()
 
+        TEST_BEGIN(NormalizeZero)
+        {
+            hmm_vec2 v2 = HMM_Vec2(0.0f, 0.0f);
+            hmm_vec3 v3 = HMM_Vec3(0.0f, 0.0f, 0.0f);
+            hmm_vec4 v4 = HMM_Vec4(0.0f, 0.0f, 0.0f, 0.0f);
+
+            {
+                hmm_vec2 result = HMM_NormalizeVec2(v2);
+                EXPECT_FLOAT_EQ(result.X, 0.0f);
+                EXPECT_FLOAT_EQ(result.Y, 0.0f);
+            }
+            {
+                hmm_vec3 result = HMM_NormalizeVec3(v3);
+                EXPECT_FLOAT_EQ(result.X, 0.0f);
+                EXPECT_FLOAT_EQ(result.Y, 0.0f);
+                EXPECT_FLOAT_EQ(result.Z, 0.0f);
+            }
+            {
+                hmm_vec4 result = HMM_NormalizeVec4(v4);
+                EXPECT_FLOAT_EQ(result.X, 0.0f);
+                EXPECT_FLOAT_EQ(result.Y, 0.0f);
+                EXPECT_FLOAT_EQ(result.Z, 0.0f);
+                EXPECT_FLOAT_EQ(result.W, 0.0f);
+            }
+
+#ifdef HANDMADE_MATH_CPP_MODE
+            {
+                hmm_vec2 result = HMM_Normalize(v2);
+                EXPECT_FLOAT_EQ(result.X, 0.0f);
+                EXPECT_FLOAT_EQ(result.Y, 0.0f);
+            }
+            {
+                hmm_vec3 result = HMM_Normalize(v3);
+                EXPECT_FLOAT_EQ(result.X, 0.0f);
+                EXPECT_FLOAT_EQ(result.Y, 0.0f);
+                EXPECT_FLOAT_EQ(result.Z, 0.0f);
+            }
+            {
+                hmm_vec4 result = HMM_Normalize(v4);
+                EXPECT_FLOAT_EQ(result.X, 0.0f);
+                EXPECT_FLOAT_EQ(result.Y, 0.0f);
+                EXPECT_FLOAT_EQ(result.Z, 0.0f);
+                EXPECT_FLOAT_EQ(result.W, 0.0f);
+            }
+#endif
+        }
+        TEST_END()
+
         TEST_BEGIN(Cross)
         {
             hmm_vec3 v1 = HMM_Vec3(1.0f, 2.0f, 3.0f);


### PR DESCRIPTION
When normalizing a vectors, we have to check whether vector length is
not zero, to avoid dividing by zero when normalizing zero-vectors.